### PR TITLE
[WIP] fix: Use ZAppEngine views as default for Redmine issue/project

### DIFF
--- a/app/views/issues/_original_edit.html.erb
+++ b/app/views/issues/_original_edit.html.erb
@@ -1,0 +1,6 @@
+<h2><%= "#{@issue.tracker_was} ##{@issue.id}" %></h2>
+
+<%= render :partial => 'edit' %>
+<% content_for :header_tags do %>
+    <%= robot_exclusion_tag %>
+<% end %>

--- a/app/views/issues/_original_index.html.erb
+++ b/app/views/issues/_original_index.html.erb
@@ -1,0 +1,92 @@
+<div class="contextual">
+  <% if User.current.allowed_to?(:add_issues, @project, :global => true) && (@project.nil? || Issue.allowed_target_trackers(@project).any?) %>
+    <%= link_to l(:label_issue_new), _new_project_issue_path(@project), :class => 'icon icon-add new-issue' %>
+  <% end %>
+  <%= actions_dropdown do %>
+    <% if @project %>
+      <%= link_to l(:field_summary), project_issues_report_path(@project), :class => 'icon icon-stats' %>
+    <% end %>
+
+    <% if User.current.allowed_to?(:import_issues, @project, :global => true) %>
+      <%= link_to l(:button_import), new_issues_import_path(:project_id => @project), :class => 'icon icon-import' %>
+    <% end %>
+
+    <%= link_to_if_authorized l(:label_settings),
+              {:controller => 'projects', :action => 'settings', :id => @project, :tab => 'issues'},
+              :class => 'icon icon-settings' if User.current.allowed_to?(:edit_project, @project) %>
+  <% end %>
+</div>
+
+<h2><%= @query.new_record? ? l(:label_issue_plural) : @query.name %></h2>
+<% html_title(@query.new_record? ? l(:label_issue_plural) : @query.name) %>
+
+<%= form_tag(_project_issues_path(@project), :method => :get, :id => 'query_form') do %>
+  <%= render :partial => 'queries/query_form' %>
+<% end %>
+
+<% if @query.valid? %>
+<% if @issues.empty? %>
+<p class="nodata"><%= l(:label_no_data) %></p>
+<% else %>
+<%= render_query_totals(@query) %>
+<%= render :partial => 'issues/list', :locals => {:issues => @issues, :query => @query} %>
+<span class="pagination"><%= pagination_links_full @issue_pages, @issue_count %></span>
+<% end %>
+
+<% other_formats_links do |f| %>
+  <%= f.link_to_with_query_parameters 'Atom', :key => User.current.atom_key %>
+  <%= f.link_to_with_query_parameters 'CSV', {}, :onclick => "showModal('csv-export-options', '350px'); return false;" %>
+  <%= f.link_to_with_query_parameters 'PDF' %>
+<% end %>
+
+<div id="csv-export-options" style="display:none;">
+  <h3 class="title"><%= l(:label_export_options, :export_format => 'CSV') %></h3>
+  <%= form_tag(_project_issues_path(@project, :format => 'csv'), :method => :get, :id => 'csv-export-form') do %>
+  <%= query_as_hidden_field_tags(@query) %>
+  <p>
+    <label><%= radio_button_tag 'c[]', '', true %> <%= l(:description_selected_columns) %></label><br />
+    <label><%= radio_button_tag 'c[]', 'all_inline' %> <%= l(:description_all_columns) %></label>
+  </p>
+  <% if @query.available_block_columns.any? %>
+    <fieldset id="csv-export-block-columns">
+      <legend>
+        <%= toggle_checkboxes_link('#csv-export-block-columns input[type=checkbox]') %>
+      </legend>
+      <% @query.available_block_columns.each do |column| %>
+        <label><%= check_box_tag 'c[]', column.name, @query.has_column?(column), :id => nil %> <%= column.caption %></label>
+      <% end %>
+    </fieldset>
+  <% end %>
+  <%= export_csv_encoding_select_tag %>
+  <% if @issue_count > Setting.issues_export_limit.to_i %>
+  <p class="icon icon-warning">
+    <%= l(:setting_issues_export_limit) %>: <%= Setting.issues_export_limit.to_i %>
+  </p>
+  <% end %>
+  <p class="buttons">
+    <%= submit_tag l(:button_export), :name => nil, :onclick => "hideModal(this);", :data => { :disable_with => false } %>
+    <%= link_to_function l(:button_cancel), "hideModal(this);" %>
+  </p>
+  <% end %>
+</div>
+
+<% end %>
+<%= call_hook(:view_issues_index_bottom, { :issues => @issues, :project => @project, :query => @query }) %>
+
+<% content_for :sidebar do %>
+    <%= render :partial => 'issues/sidebar' %>
+<% end %>
+
+<% content_for :header_tags do %>
+    <%= auto_discovery_link_tag(:atom,
+                                {:query_id => @query, :format => 'atom',
+                                 :page => nil, :key => User.current.atom_key},
+                                :title => l(:label_issue_plural)) %>
+    <%= auto_discovery_link_tag(:atom,
+                                {:controller => 'journals', :action => 'index',
+                                 :query_id => @query, :format => 'atom',
+                                 :page => nil, :key => User.current.atom_key},
+                                :title => l(:label_changes_details)) %>
+<% end %>
+
+<%= context_menu %>

--- a/app/views/issues/_original_new.html.erb
+++ b/app/views/issues/_original_new.html.erb
@@ -1,0 +1,49 @@
+<%= title l(:label_issue_new) %>
+
+<%= call_hook(:view_issues_new_top, {:issue => @issue}) %>
+
+<%= labelled_form_for @issue, :url => _project_issues_path(@project),
+                             :html => {:id => 'issue-form', :multipart => true} do |f| %>
+  <%= error_messages_for 'issue' %>
+  <%= hidden_field_tag 'copy_from', params[:copy_from] if params[:copy_from] %>
+  <div class="box tabular">
+    <div id="all_attributes">
+    <%= render :partial => 'issues/form', :locals => {:f => f} %>
+    </div>
+
+    <% if @copy_from && Setting.link_copied_issue == 'ask' %>
+    <p>
+      <label for="link_copy"><%= l(:label_link_copied_issue) %></label>
+      <%= check_box_tag 'link_copy', '1', @link_copy %>
+    </p>
+    <% end %>
+    <% if @copy_from && @copy_from.attachments.any? %>
+    <p>
+      <label for="copy_attachments"><%= l(:label_copy_attachments) %></label>
+      <%= check_box_tag 'copy_attachments', '1', @copy_attachments %>
+    </p>
+    <% end %>
+    <% if @copy_from && !@copy_from.leaf? %>
+    <p>
+      <label for="copy_subtasks"><%= l(:label_copy_subtasks) %></label>
+      <%= check_box_tag 'copy_subtasks', '1', @copy_subtasks %>
+    </p>
+    <% end %>
+
+    <p id="attachments_form"><label><%= l(:label_attachment_plural) %></label><%= render :partial => 'attachments/form', :locals => {:container => @issue} %></p>
+
+    <div id="watchers_form_container">
+      <%= render :partial => 'issues/watchers_form' %>
+    </div>
+  </div>
+
+  <%= submit_tag l(:button_create) %>
+  <% if params[:back_url] && params[:issue] && params[:issue][:parent_issue_id] %>
+    <%= submit_tag l(:button_create_and_follow), name: 'follow' %>
+  <% end %>
+  <%= submit_tag l(:button_create_and_continue), :name => 'continue' %>
+<% end %>
+
+<% content_for :header_tags do %>
+    <%= robot_exclusion_tag %>
+<% end %>

--- a/app/views/issues/_original_show.html.erb
+++ b/app/views/issues/_original_show.html.erb
@@ -1,0 +1,153 @@
+<%= render :partial => 'action_menu' %>
+
+<h2 class="inline-flex"><%= issue_heading(@issue) %></h2>
+<%= issue_status_type_badge(@issue.status) %>
+<% if @issue.is_private? %>
+  <span class="badge badge-private private"><%= l(:field_is_private) %></span>
+<% end %>
+
+<div class="<%= @issue.css_classes %> details">
+  <% if @prev_issue_id || @next_issue_id %>
+    <div class="next-prev-links contextual">
+      <%= link_to_if @prev_issue_id,
+                     "\xc2\xab #{l(:label_previous)}",
+                     (@prev_issue_id ? issue_path(@prev_issue_id) : nil),
+                     :title => "##{@prev_issue_id}",
+                     :accesskey => accesskey(:previous) %> |
+      <% if @issue_position && @issue_count %>
+        <span class="position">
+          <%= link_to_if @query_path,
+                         l(:label_item_position, :position => @issue_position, :count => @issue_count),
+                         @query_path %>
+        </span> |
+      <% end %>
+      <%= link_to_if @next_issue_id,
+                     "#{l(:label_next)} \xc2\xbb",
+                     (@next_issue_id ? issue_path(@next_issue_id) : nil),
+                     :title => "##{@next_issue_id}",
+                     :accesskey => accesskey(:next) %>
+    </div>
+  <% end %>
+
+  <div class="gravatar-with-child">
+    <%= author_avatar(@issue.author, :size => "50") %>
+    <%= assignee_avatar(@issue.assigned_to, :size => "22", :class => "gravatar-child") if @issue.assigned_to %>
+  </div>
+
+<div class="subject">
+<%= render_issue_subject_with_tree(@issue) %>
+</div>
+        <p class="author">
+        <%= authoring @issue.created_on, @issue.author %>.
+        <% if @issue.created_on != @issue.updated_on %>
+        <%= l(:label_updated_time, time_tag(@issue.updated_on)).html_safe %>.
+        <% end %>
+        </p>
+
+<div class="attributes">
+<%= issue_fields_rows do |rows|
+  rows.left l(:field_status), @issue.status.name, :class => 'status'
+  rows.left l(:field_priority), @issue.priority.name, :class => 'priority'
+
+  unless @issue.disabled_core_fields.include?('assigned_to_id')
+    rows.left l(:field_assigned_to), (@issue.assigned_to ? link_to_principal(@issue.assigned_to) : "-"), :class => 'assigned-to'
+  end
+  unless @issue.disabled_core_fields.include?('category_id') || (@issue.category.nil? && @issue.project.issue_categories.none?)
+    rows.left l(:field_category), (@issue.category ? @issue.category.name : "-"), :class => 'category'
+  end
+  unless @issue.disabled_core_fields.include?('fixed_version_id') || (@issue.fixed_version.nil? && @issue.assignable_versions.none?)
+    rows.left l(:field_fixed_version), (@issue.fixed_version ? link_to_version(@issue.fixed_version) : "-"), :class => 'fixed-version'
+  end
+
+  unless @issue.disabled_core_fields.include?('start_date')
+    rows.right l(:field_start_date), format_date(@issue.start_date), :class => 'start-date'
+  end
+  unless @issue.disabled_core_fields.include?('due_date')
+    rows.right l(:field_due_date), issue_due_date_details(@issue), :class => 'due-date'
+  end
+  unless @issue.disabled_core_fields.include?('done_ratio')
+    rows.right l(:field_done_ratio), progress_bar(@issue.done_ratio, :legend => "#{@issue.done_ratio}%"), :class => 'progress'
+  end
+  unless @issue.disabled_core_fields.include?('estimated_hours')
+    rows.right l(:field_estimated_hours), issue_estimated_hours_details(@issue), :class => 'estimated-hours'
+  end
+  if User.current.allowed_to?(:view_time_entries, @project) && @issue.total_spent_hours > 0
+    rows.right l(:label_spent_time), issue_spent_hours_details(@issue), :class => 'spent-time'
+  end
+end %>
+<%= render_half_width_custom_fields_rows(@issue) %>
+<%= call_hook(:view_issues_show_details_bottom, :issue => @issue) %>
+</div>
+
+<% if @issue.description? %>
+<hr />
+<div class="description">
+  <div class="contextual">
+  <%= link_to l(:button_quote), quoted_issue_path(@issue), :remote => true, :method => 'post', :class => 'icon icon-comment' if @issue.notes_addable? %>
+  </div>
+
+  <p><strong><%=l(:field_description)%></strong></p>
+  <div class="wiki">
+  <%= textilizable @issue, :description, :attachments => @issue.attachments %>
+  </div>
+</div>
+<% end %>
+<% if @issue.attachments.any? %>
+  <hr />
+  <p><strong><%=l(:label_attachment_plural)%></strong></p>
+  <%= link_to_attachments @issue, :thumbnails => true %>
+<% end %>
+
+<%= render_full_width_custom_fields_rows(@issue) %>
+
+<%= call_hook(:view_issues_show_description_bottom, :issue => @issue) %>
+
+<% if !@issue.leaf? || User.current.allowed_to?(:manage_subtasks, @project) %>
+<hr />
+<div id="issue_tree">
+<%= render :partial => 'subtasks' %>
+</div>
+<% end %>
+
+<% if @relations.present? || User.current.allowed_to?(:manage_issue_relations, @project) %>
+<hr />
+<div id="relations">
+<%= render :partial => 'relations' %>
+</div>
+<% end %>
+
+</div>
+
+<%= render partial: 'action_menu_edit' if User.current.wants_comments_in_reverse_order? %>
+
+<%= call_hook(:view_issues_show_after_details, :issue => @issue) %>
+
+<div id="history">
+<%= render_tabs issue_history_tabs, issue_history_default_tab %>
+</div>
+
+<%= render partial: 'action_menu_edit' unless User.current.wants_comments_in_reverse_order? %>
+
+<% other_formats_links do |f| %>
+  <%= f.link_to 'Atom', :url => {:key => User.current.atom_key} %>
+  <%= f.link_to 'PDF' %>
+<% end %>
+
+<% html_title "#{@issue.tracker.name} ##{@issue.id}: #{@issue.subject}" %>
+
+<% content_for :sidebar do %>
+  <%= render :partial => 'issues/sidebar' %>
+
+  <% if User.current.allowed_to?(:add_issue_watchers, @project) ||
+    (@issue.watchers.present? && User.current.allowed_to?(:view_issue_watchers, @project)) %>
+    <div id="watchers">
+      <%= render :partial => 'watchers/watchers', :locals => {:watched => @issue} %>
+    </div>
+  <% end %>
+<% end %>
+
+<% content_for :header_tags do %>
+    <%= auto_discovery_link_tag(:atom, {:format => 'atom', :key => User.current.atom_key}, :title => "#{@issue.project} - #{@issue.tracker} ##{@issue.id}: #{@issue.subject}") %>
+<% end %>
+
+<%= context_menu %>

--- a/app/views/issues/edit.html.erb
+++ b/app/views/issues/edit.html.erb
@@ -1,6 +1,24 @@
-<h2><%= "#{@issue.tracker_was} ##{@issue.id}" %></h2>
-
-<%= render :partial => 'edit' %>
-<% content_for :header_tags do %>
-    <%= robot_exclusion_tag %>
-<% end %>
+<%
+  ZAppEngine.start_capture_requested_assets
+  override = ViewOverride.issue_edit
+                         .active_instance
+                         .select { |vo| vo.matches?(project: @project, tracker: @issue.tracker) }
+  if override.any?
+    atp_log("HIER more than one matching override") if override.length > 1
+    snippet = override.first.vo_code_snippet
+    begin
+      result = render_snippet(snippet, { view_override: override.first })
+    rescue => e
+      atp_log "Override exception: issue ##{@issue.id}"
+      atp_log "Override exception: controller #{controller_name}"
+      atp_log "Override exception: action #{action_name}"
+      atp_log "Override exception: ViewOverridesHelper defined #{Object.const_defined?(:ViewOverridesHelper)}"
+      atp_log "Override exception: ViewOverridesHelper#render_snippet defined #{ViewOverridesHelper.respond_to?('render_snippet')}" if Object.const_defined?(:ViewOverridesHelper)
+      raise e
+    end
+  end
+  to_render = result.present? ? result : (render partial: 'original_edit')
+%>
+<%= render partial: 'z_app_engine/requested_assets' %>
+<%= render partial: 'z_app_engine/entity_picker_setup' %>
+<%= to_render %>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -1,92 +1,50 @@
-<div class="contextual">
-  <% if User.current.allowed_to?(:add_issues, @project, :global => true) && (@project.nil? || Issue.allowed_target_trackers(@project).any?) %>
-    <%= link_to l(:label_issue_new), _new_project_issue_path(@project), :class => 'icon icon-add new-issue' %>
-  <% end %>
-  <%= actions_dropdown do %>
-    <% if @project %>
-      <%= link_to l(:field_summary), project_issues_report_path(@project), :class => 'icon icon-stats' %>
-    <% end %>
+<%
+  ZAppEngine.start_capture_requested_assets
+  overrides = @project.nil? ? [] : ViewOverride.issue_list
+                                               .active_instance
+                                               .select { |vo| vo.matches?(project: @project) }
+  results = {}
+  overrides.map do |override|
+    snippet = override.vo_code_snippet
+    results[override] = render_snippet(snippet, { view_override: override })
+  end
+%>
+<%= render partial: 'z_app_engine/requested_assets' %>
+<% if overrides.any?  %>
+  <div class="card">
+    <!-- Tabs for the templates -->
+    <ul class="nav nav-tabs">
+      <li class="nav-item">
+        <a class="nav-link active" href='#index' role="tab" data-toggle="tab">
+          Index
+        </a>
+      </li>
 
-    <% if User.current.allowed_to?(:import_issues, @project, :global => true) %>
-      <%= link_to l(:button_import), new_issues_import_path(:project_id => @project), :class => 'icon icon-import' %>
-    <% end %>
-
-    <%= link_to_if_authorized l(:label_settings),
-              {:controller => 'projects', :action => 'settings', :id => @project, :tab => 'issues'},
-              :class => 'icon icon-settings' if User.current.allowed_to?(:edit_project, @project) %>
-  <% end %>
-</div>
-
-<h2><%= @query.new_record? ? l(:label_issue_plural) : @query.name %></h2>
-<% html_title(@query.new_record? ? l(:label_issue_plural) : @query.name) %>
-
-<%= form_tag(_project_issues_path(@project), :method => :get, :id => 'query_form') do %>
-  <%= render :partial => 'queries/query_form' %>
-<% end %>
-
-<% if @query.valid? %>
-<% if @issues.empty? %>
-<p class="nodata"><%= l(:label_no_data) %></p>
-<% else %>
-<%= render_query_totals(@query) %>
-<%= render :partial => 'issues/list', :locals => {:issues => @issues, :query => @query} %>
-<span class="pagination"><%= pagination_links_full @issue_pages, @issue_count %></span>
-<% end %>
-
-<% other_formats_links do |f| %>
-  <%= f.link_to_with_query_parameters 'Atom', :key => User.current.atom_key %>
-  <%= f.link_to_with_query_parameters 'CSV', {}, :onclick => "showModal('csv-export-options', '350px'); return false;" %>
-  <%= f.link_to_with_query_parameters 'PDF' %>
-<% end %>
-
-<div id="csv-export-options" style="display:none;">
-  <h3 class="title"><%= l(:label_export_options, :export_format => 'CSV') %></h3>
-  <%= form_tag(_project_issues_path(@project, :format => 'csv'), :method => :get, :id => 'csv-export-form') do %>
-  <%= query_as_hidden_field_tags(@query) %>
-  <p>
-    <label><%= radio_button_tag 'c[]', '', true %> <%= l(:description_selected_columns) %></label><br />
-    <label><%= radio_button_tag 'c[]', 'all_inline' %> <%= l(:description_all_columns) %></label>
-  </p>
-  <% if @query.available_block_columns.any? %>
-    <fieldset id="csv-export-block-columns">
-      <legend>
-        <%= toggle_checkboxes_link('#csv-export-block-columns input[type=checkbox]') %>
-      </legend>
-      <% @query.available_block_columns.each do |column| %>
-        <label><%= check_box_tag 'c[]', column.name, @query.has_column?(column), :id => nil %> <%= column.caption %></label>
+      <% overrides.each do |override| %>
+        <li class="nav-item">
+          <a class="nav-link" href='#<%= override.name.gsub(/\s+/, '') %>' role="tab" data-toggle="tab">
+            <%= override.name %>
+          </a>
+        </li>
       <% end %>
-    </fieldset>
-  <% end %>
-  <%= export_csv_encoding_select_tag %>
-  <% if @issue_count > Setting.issues_export_limit.to_i %>
-  <p class="icon icon-warning">
-    <%= l(:setting_issues_export_limit) %>: <%= Setting.issues_export_limit.to_i %>
-  </p>
-  <% end %>
-  <p class="buttons">
-    <%= submit_tag l(:button_export), :name => nil, :onclick => "hideModal(this);", :data => { :disable_with => false } %>
-    <%= link_to_function l(:button_cancel), "hideModal(this);" %>
-  </p>
-  <% end %>
-</div>
+    </ul>
+    <!-- Tab panes -->
+    <div class="tab-content">
+      <div class="tab-pane active" role="tabpanel" id="index">
+        <div>
+          <%= render :parent %>
+        </div>
+      </div>
 
+      <% overrides.each do |override| %>
+        <div class="tab-pane" role="tabpanel" id="<%= override.name.gsub(/\s+/, '') %>">
+          <div>
+            <%= results[override] %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% else %>
+  <%= render partial: 'original_index' %>
 <% end %>
-<%= call_hook(:view_issues_index_bottom, { :issues => @issues, :project => @project, :query => @query }) %>
-
-<% content_for :sidebar do %>
-    <%= render :partial => 'issues/sidebar' %>
-<% end %>
-
-<% content_for :header_tags do %>
-    <%= auto_discovery_link_tag(:atom,
-                                {:query_id => @query, :format => 'atom',
-                                 :page => nil, :key => User.current.atom_key},
-                                :title => l(:label_issue_plural)) %>
-    <%= auto_discovery_link_tag(:atom,
-                                {:controller => 'journals', :action => 'index',
-                                 :query_id => @query, :format => 'atom',
-                                 :page => nil, :key => User.current.atom_key},
-                                :title => l(:label_changes_details)) %>
-<% end %>
-
-<%= context_menu %>

--- a/app/views/issues/new.html.erb
+++ b/app/views/issues/new.html.erb
@@ -1,49 +1,23 @@
-<%= title l(:label_issue_new) %>
-
-<%= call_hook(:view_issues_new_top, {:issue => @issue}) %>
-
-<%= labelled_form_for @issue, :url => _project_issues_path(@project),
-                             :html => {:id => 'issue-form', :multipart => true} do |f| %>
-  <%= error_messages_for 'issue' %>
-  <%= hidden_field_tag 'copy_from', params[:copy_from] if params[:copy_from] %>
-  <div class="box tabular">
-    <div id="all_attributes">
-    <%= render :partial => 'issues/form', :locals => {:f => f} %>
-    </div>
-
-    <% if @copy_from && Setting.link_copied_issue == 'ask' %>
-    <p>
-      <label for="link_copy"><%= l(:label_link_copied_issue) %></label>
-      <%= check_box_tag 'link_copy', '1', @link_copy %>
-    </p>
-    <% end %>
-    <% if @copy_from && @copy_from.attachments.any? %>
-    <p>
-      <label for="copy_attachments"><%= l(:label_copy_attachments) %></label>
-      <%= check_box_tag 'copy_attachments', '1', @copy_attachments %>
-    </p>
-    <% end %>
-    <% if @copy_from && !@copy_from.leaf? %>
-    <p>
-      <label for="copy_subtasks"><%= l(:label_copy_subtasks) %></label>
-      <%= check_box_tag 'copy_subtasks', '1', @copy_subtasks %>
-    </p>
-    <% end %>
-
-    <p id="attachments_form"><label><%= l(:label_attachment_plural) %></label><%= render :partial => 'attachments/form', :locals => {:container => @issue} %></p>
-
-    <div id="watchers_form_container">
-      <%= render :partial => 'issues/watchers_form' %>
-    </div>
-  </div>
-
-  <%= submit_tag l(:button_create) %>
-  <% if params[:back_url] && params[:issue] && params[:issue][:parent_issue_id] %>
-    <%= submit_tag l(:button_create_and_follow), name: 'follow' %>
-  <% end %>
-  <%= submit_tag l(:button_create_and_continue), :name => 'continue' %>
-<% end %>
-
-<% content_for :header_tags do %>
-    <%= robot_exclusion_tag %>
-<% end %>
+<%
+  ZAppEngine.start_capture_requested_assets
+  override = ViewOverride.issue_create
+                         .active_instance
+                         .select { |vo| vo.matches?(project: @project) }
+ if override.any?
+    atp_log("HIER more than one matching override") if override.length > 1
+    snippet = override.first.vo_code_snippet
+    begin
+      result = render_snippet(snippet, { view_override: override.first })
+    rescue => e
+      atp_log "Override exception: controller #{controller_name}"
+      atp_log "Override exception: action #{action_name}"
+      atp_log "Override exception: ViewOverridesHelper defined #{Object.const_defined?(:ViewOverridesHelper)}"
+      atp_log "Override exception: ViewOverridesHelper#render_snippet defined #{ViewOverridesHelper.respond_to?('render_snippet')}" if Object.const_defined?(:ViewOverridesHelper)
+      raise e
+    end
+  end
+  to_render = result.present? ? result : (render partial: 'original_new')
+%>
+<%= render partial: 'z_app_engine/requested_assets' %>
+<%= render partial: 'z_app_engine/entity_picker_setup' %>
+<%= to_render %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,153 +1,24 @@
-<%= render :partial => 'action_menu' %>
-
-<h2 class="inline-flex"><%= issue_heading(@issue) %></h2>
-<%= issue_status_type_badge(@issue.status) %>
-<% if @issue.is_private? %>
-  <span class="badge badge-private private"><%= l(:field_is_private) %></span>
-<% end %>
-
-<div class="<%= @issue.css_classes %> details">
-  <% if @prev_issue_id || @next_issue_id %>
-    <div class="next-prev-links contextual">
-      <%= link_to_if @prev_issue_id,
-                     "\xc2\xab #{l(:label_previous)}",
-                     (@prev_issue_id ? issue_path(@prev_issue_id) : nil),
-                     :title => "##{@prev_issue_id}",
-                     :accesskey => accesskey(:previous) %> |
-      <% if @issue_position && @issue_count %>
-        <span class="position">
-          <%= link_to_if @query_path,
-                         l(:label_item_position, :position => @issue_position, :count => @issue_count),
-                         @query_path %>
-        </span> |
-      <% end %>
-      <%= link_to_if @next_issue_id,
-                     "#{l(:label_next)} \xc2\xbb",
-                     (@next_issue_id ? issue_path(@next_issue_id) : nil),
-                     :title => "##{@next_issue_id}",
-                     :accesskey => accesskey(:next) %>
-    </div>
-  <% end %>
-
-  <div class="gravatar-with-child">
-    <%= author_avatar(@issue.author, :size => "50") %>
-    <%= assignee_avatar(@issue.assigned_to, :size => "22", :class => "gravatar-child") if @issue.assigned_to %>
-  </div>
-
-<div class="subject">
-<%= render_issue_subject_with_tree(@issue) %>
-</div>
-        <p class="author">
-        <%= authoring @issue.created_on, @issue.author %>.
-        <% if @issue.created_on != @issue.updated_on %>
-        <%= l(:label_updated_time, time_tag(@issue.updated_on)).html_safe %>.
-        <% end %>
-        </p>
-
-<div class="attributes">
-<%= issue_fields_rows do |rows|
-  rows.left l(:field_status), @issue.status.name, :class => 'status'
-  rows.left l(:field_priority), @issue.priority.name, :class => 'priority'
-
-  unless @issue.disabled_core_fields.include?('assigned_to_id')
-    rows.left l(:field_assigned_to), (@issue.assigned_to ? link_to_principal(@issue.assigned_to) : "-"), :class => 'assigned-to'
+<%
+  ZAppEngine.start_capture_requested_assets
+  override = ViewOverride.issue_detail
+                         .active_instance
+                         .select { |vo| vo.matches?(project: @project, tracker: @issue.tracker) }
+  if override.any?
+    atp_log("HIER more than one matching override") if override.length > 1
+    snippet = override.first.vo_code_snippet
+    begin
+      result = render_snippet(snippet, { view_override: override.first })
+    rescue => e
+      atp_log "Override exception: issue ##{@issue.id}"
+      atp_log "Override exception: controller #{controller_name}"
+      atp_log "Override exception: action #{action_name}"
+      atp_log "Override exception: ViewOverridesHelper defined #{Object.const_defined?(:ViewOverridesHelper)}"
+      atp_log "Override exception: ViewOverridesHelper#render_snippet defined #{ViewOverridesHelper.respond_to?('render_snippet')}" if Object.const_defined?(:ViewOverridesHelper)
+      raise e
+    end
   end
-  unless @issue.disabled_core_fields.include?('category_id') || (@issue.category.nil? && @issue.project.issue_categories.none?)
-    rows.left l(:field_category), (@issue.category ? @issue.category.name : "-"), :class => 'category'
-  end
-  unless @issue.disabled_core_fields.include?('fixed_version_id') || (@issue.fixed_version.nil? && @issue.assignable_versions.none?)
-    rows.left l(:field_fixed_version), (@issue.fixed_version ? link_to_version(@issue.fixed_version) : "-"), :class => 'fixed-version'
-  end
-
-  unless @issue.disabled_core_fields.include?('start_date')
-    rows.right l(:field_start_date), format_date(@issue.start_date), :class => 'start-date'
-  end
-  unless @issue.disabled_core_fields.include?('due_date')
-    rows.right l(:field_due_date), issue_due_date_details(@issue), :class => 'due-date'
-  end
-  unless @issue.disabled_core_fields.include?('done_ratio')
-    rows.right l(:field_done_ratio), progress_bar(@issue.done_ratio, :legend => "#{@issue.done_ratio}%"), :class => 'progress'
-  end
-  unless @issue.disabled_core_fields.include?('estimated_hours')
-    rows.right l(:field_estimated_hours), issue_estimated_hours_details(@issue), :class => 'estimated-hours'
-  end
-  if User.current.allowed_to?(:view_time_entries, @project) && @issue.total_spent_hours > 0
-    rows.right l(:label_spent_time), issue_spent_hours_details(@issue), :class => 'spent-time'
-  end
-end %>
-<%= render_half_width_custom_fields_rows(@issue) %>
-<%= call_hook(:view_issues_show_details_bottom, :issue => @issue) %>
-</div>
-
-<% if @issue.description? %>
-<hr />
-<div class="description">
-  <div class="contextual">
-  <%= link_to l(:button_quote), quoted_issue_path(@issue), :remote => true, :method => 'post', :class => 'icon icon-comment' if @issue.notes_addable? %>
-  </div>
-
-  <p><strong><%=l(:field_description)%></strong></p>
-  <div class="wiki">
-  <%= textilizable @issue, :description, :attachments => @issue.attachments %>
-  </div>
-</div>
-<% end %>
-<% if @issue.attachments.any? %>
-  <hr />
-  <p><strong><%=l(:label_attachment_plural)%></strong></p>
-  <%= link_to_attachments @issue, :thumbnails => true %>
-<% end %>
-
-<%= render_full_width_custom_fields_rows(@issue) %>
-
-<%= call_hook(:view_issues_show_description_bottom, :issue => @issue) %>
-
-<% if !@issue.leaf? || User.current.allowed_to?(:manage_subtasks, @project) %>
-<hr />
-<div id="issue_tree">
-<%= render :partial => 'subtasks' %>
-</div>
-<% end %>
-
-<% if @relations.present? || User.current.allowed_to?(:manage_issue_relations, @project) %>
-<hr />
-<div id="relations">
-<%= render :partial => 'relations' %>
-</div>
-<% end %>
-
-</div>
-
-<%= render partial: 'action_menu_edit' if User.current.wants_comments_in_reverse_order? %>
-
-<%= call_hook(:view_issues_show_after_details, :issue => @issue) %>
-
-<div id="history">
-<%= render_tabs issue_history_tabs, issue_history_default_tab %>
-</div>
-
-<%= render partial: 'action_menu_edit' unless User.current.wants_comments_in_reverse_order? %>
-
-<% other_formats_links do |f| %>
-  <%= f.link_to 'Atom', :url => {:key => User.current.atom_key} %>
-  <%= f.link_to 'PDF' %>
-<% end %>
-
-<% html_title "#{@issue.tracker.name} ##{@issue.id}: #{@issue.subject}" %>
-
-<% content_for :sidebar do %>
-  <%= render :partial => 'issues/sidebar' %>
-
-  <% if User.current.allowed_to?(:add_issue_watchers, @project) ||
-    (@issue.watchers.present? && User.current.allowed_to?(:view_issue_watchers, @project)) %>
-    <div id="watchers">
-      <%= render :partial => 'watchers/watchers', :locals => {:watched => @issue} %>
-    </div>
-  <% end %>
-<% end %>
-
-<% content_for :header_tags do %>
-    <%= auto_discovery_link_tag(:atom, {:format => 'atom', :key => User.current.atom_key}, :title => "#{@issue.project} - #{@issue.tracker} ##{@issue.id}: #{@issue.subject}") %>
-<% end %>
-
-<%= context_menu %>
+  to_render = result.present? ? result : (render partial: 'original_show')
+%>
+<%= render partial: 'z_app_engine/requested_assets' %>
+<%= render partial: 'z_app_engine/entity_picker_setup' %>
+<%= to_render %>

--- a/app/views/projects/_original_show.html.erb
+++ b/app/views/projects/_original_show.html.erb
@@ -1,0 +1,157 @@
+<div class="contextual">
+  <%= bookmark_link @project %>
+
+  <%= actions_dropdown do %>
+  <% if User.current.allowed_to?(:add_subprojects, @project) %>
+    <%= link_to l(:label_subproject_new), new_project_path(:parent_id => @project), :class => 'icon icon-add' %>
+  <% end %>
+  <% if User.current.allowed_to?(:close_project, @project) %>
+    <% if @project.active? %>
+      <%= link_to l(:button_close), close_project_path(@project), :data => {:confirm => l(:text_are_you_sure)}, :method => :post, :class => 'icon icon-lock' %>
+    <% else %>
+      <%= link_to l(:button_reopen), reopen_project_path(@project), :data => {:confirm => l(:text_are_you_sure)}, :method => :post, :class => 'icon icon-unlock' %>
+    <% end %>
+  <% end %>
+  <% if @project.deletable? %>
+    <%= link_to l(:button_delete), project_path(@project), :method => :delete, :class => 'icon icon-del' %>
+  <% end %>
+  <%= link_to_if_authorized l(:label_settings),
+              {:controller => 'projects', :action => 'settings', :id => @project},
+              :class => 'icon icon-settings' if User.current.allowed_to?(:edit_project, @project) %>
+  <% end %>
+</div>
+
+<h2><%=l(:label_overview)%></h2>
+
+<% unless @project.active? %>
+  <p class="warning"><span class="icon icon-lock"><%= l(:text_project_closed) %></span></p>
+<% end %>
+
+<div class="splitcontent">
+<div class="splitcontentleft">
+  <% if @project.description.present? %>
+  <div class="wiki">
+    <%= textilizable @project.description %>
+  </div>
+  <% end %>
+  <% if @project.homepage.present? || @project.visible_custom_field_values.any? { |o| o.value.present? } %>
+  <ul>
+  <% unless @project.homepage.blank? %>
+    <li><span class="label"><%=l(:field_homepage)%>:</span> <%= link_to_if uri_with_safe_scheme?(@project.homepage), @project.homepage, @project.homepage %></li>
+  <% end %>
+  <% render_custom_field_values(@project) do |custom_field, formatted| %>
+    <li class="<%= custom_field.css_classes %>"><span class="label"><%= custom_field.name %>:</span> <%= formatted %></li>
+  <% end %>
+  </ul>
+  <% end %>
+
+  <% if User.current.allowed_to?(:view_issues, @project) %>
+  <div class="issues box">
+    <h3 class="icon icon-issue">
+      <%=l(:label_issue_tracking)%>&nbsp;
+      <%= link_to l(:label_details),
+            project_issues_report_details_path(@project, :detail => 'tracker'),
+            :class => 'icon-only icon-zoom-in',
+            :title => l(:label_details) %>
+    </h3>
+    <% if @trackers.present? %>
+    <table class="list issue-report">
+      <thead>
+        <tr>
+          <th></th>
+          <th><%=l(:label_open_issues_plural)%></th>
+          <th><%=l(:label_closed_issues_plural)%></th>
+          <th><%=l(:label_total)%></th>
+        </tr>
+      </thead>
+      <tbody>
+      <% @trackers.each do |tracker| %>
+        <tr>
+          <td class="name">
+            <%= link_to tracker.name, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id), :title => tracker.description %>
+          </td>
+          <td>
+            <%= link_to @open_issues_by_tracker[tracker].to_i, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id) %>
+          </td>
+          <td>
+            <%= link_to (@total_issues_by_tracker[tracker].to_i - @open_issues_by_tracker[tracker].to_i), project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id, :status_id => 'c') %>
+          </td>
+          <td class="total">
+            <%= link_to @total_issues_by_tracker[tracker].to_i, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id, :status_id => '*') %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+    <% end %>
+    <p>
+      <%= link_to l(:label_issue_view_all), project_issues_path(@project, :set_filter => 1) %>
+      | <%= link_to l(:field_summary), project_issues_report_path(@project) %>
+      <% if User.current.allowed_to?(:view_calendar, @project, :global => true) %>
+        | <%= link_to l(:label_calendar), project_calendar_path(@project) %>
+      <% end %>
+      <% if User.current.allowed_to?(:view_gantt, @project, :global => true) %>
+        | <%= link_to l(:label_gantt), project_gantt_path(@project) %>
+      <% end %>
+    </p>
+  </div>
+  <% end %>
+
+  <% if User.current.allowed_to?(:view_time_entries, @project) %>
+  <div class="spent_time box">
+    <h3 class="icon icon-time"><%= l(:label_time_tracking) %></h3>
+    <ul>
+      <% if @total_estimated_hours.present? %>
+        <li><%= l(:field_estimated_hours) %>: <%= l_hours(@total_estimated_hours) %>
+      <% end %>
+      <% if @total_hours.present? %>
+          <li><%= l(:label_spent_time) %>: <%= l_hours(@total_hours) %>
+      <% end %>
+    </ul>
+    <p>
+    <% if User.current.allowed_to?(:log_time, @project) %>
+      <%= link_to l(:button_log_time), new_project_time_entry_path(@project) %> |
+    <% end %>
+    <%= link_to(l(:label_details), project_time_entries_path(@project)) %> |
+    <%= link_to(l(:label_report), report_project_time_entries_path(@project)) %>
+    </p>
+  </div>
+<% end %>
+  <%= call_hook(:view_projects_show_left, :project => @project) %>
+</div>
+
+<div class="splitcontentright">
+  <% if @news.any? && authorize_for('news', 'index') %>
+  <div class="news box">
+    <h3 class="icon icon-news"><%=l(:label_news_latest)%></h3>
+    <%= render :partial => 'news/news', :collection => @news %>
+    <p><%= link_to l(:label_news_view_all), project_news_index_path(@project) %></p>
+  </div>
+  <% end %>
+
+  <%= render :partial => 'members_box' %>
+
+  <% if @subprojects.any? %>
+  <div class="projects box">
+    <h3 class="icon icon-projects"><%=l(:label_subproject_plural)%></h3>
+	<ul class="subprojects">
+	  <% @subprojects.each do |project| %>
+	  <li><%= link_to(project.name, project_path(project), :class => project.css_classes).html_safe %></li>
+	  <% end %>
+    </ul>
+  </div>
+  <% end %>
+
+  <%= call_hook(:view_projects_show_right, :project => @project) %>
+</div>
+</div>
+
+<% content_for :sidebar do %>
+  <%= call_hook(:view_projects_show_sidebar_bottom, :project => @project) %>
+<% end %>
+
+<% content_for :header_tags do %>
+<%= auto_discovery_link_tag(:atom, {:controller => 'activities', :action => 'index', :id => @project, :format => 'atom', :key => User.current.atom_key}) %>
+<% end %>
+
+<% html_title(l(:label_overview)) -%>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,157 +1,21 @@
-<div class="contextual">
-  <%= bookmark_link @project %>
-
-  <%= actions_dropdown do %>
-  <% if User.current.allowed_to?(:add_subprojects, @project) %>
-    <%= link_to l(:label_subproject_new), new_project_path(:parent_id => @project), :class => 'icon icon-add' %>
-  <% end %>
-  <% if User.current.allowed_to?(:close_project, @project) %>
-    <% if @project.active? %>
-      <%= link_to l(:button_close), close_project_path(@project), :data => {:confirm => l(:text_are_you_sure)}, :method => :post, :class => 'icon icon-lock' %>
-    <% else %>
-      <%= link_to l(:button_reopen), reopen_project_path(@project), :data => {:confirm => l(:text_are_you_sure)}, :method => :post, :class => 'icon icon-unlock' %>
-    <% end %>
-  <% end %>
-  <% if @project.deletable? %>
-    <%= link_to l(:button_delete), project_path(@project), :method => :delete, :class => 'icon icon-del' %>
-  <% end %>
-  <%= link_to_if_authorized l(:label_settings),
-              {:controller => 'projects', :action => 'settings', :id => @project},
-              :class => 'icon icon-settings' if User.current.allowed_to?(:edit_project, @project) %>
-  <% end %>
-</div>
-
-<h2><%=l(:label_overview)%></h2>
-
-<% unless @project.active? %>
-  <p class="warning"><span class="icon icon-lock"><%= l(:text_project_closed) %></span></p>
-<% end %>
-
-<div class="splitcontent">
-<div class="splitcontentleft">
-  <% if @project.description.present? %>
-  <div class="wiki">
-    <%= textilizable @project.description %>
-  </div>
-  <% end %>
-  <% if @project.homepage.present? || @project.visible_custom_field_values.any? { |o| o.value.present? } %>
-  <ul>
-  <% unless @project.homepage.blank? %>
-    <li><span class="label"><%=l(:field_homepage)%>:</span> <%= link_to_if uri_with_safe_scheme?(@project.homepage), @project.homepage, @project.homepage %></li>
-  <% end %>
-  <% render_custom_field_values(@project) do |custom_field, formatted| %>
-    <li class="<%= custom_field.css_classes %>"><span class="label"><%= custom_field.name %>:</span> <%= formatted %></li>
-  <% end %>
-  </ul>
-  <% end %>
-
-  <% if User.current.allowed_to?(:view_issues, @project) %>
-  <div class="issues box">
-    <h3 class="icon icon-issue">
-      <%=l(:label_issue_tracking)%>&nbsp;
-      <%= link_to l(:label_details),
-            project_issues_report_details_path(@project, :detail => 'tracker'),
-            :class => 'icon-only icon-zoom-in',
-            :title => l(:label_details) %>
-    </h3>
-    <% if @trackers.present? %>
-    <table class="list issue-report">
-      <thead>
-        <tr>
-          <th></th>
-          <th><%=l(:label_open_issues_plural)%></th>
-          <th><%=l(:label_closed_issues_plural)%></th>
-          <th><%=l(:label_total)%></th>
-        </tr>
-      </thead>
-      <tbody>
-      <% @trackers.each do |tracker| %>
-        <tr>
-          <td class="name">
-            <%= link_to tracker.name, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id), :title => tracker.description %>
-          </td>
-          <td>
-            <%= link_to @open_issues_by_tracker[tracker].to_i, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id) %>
-          </td>
-          <td>
-            <%= link_to (@total_issues_by_tracker[tracker].to_i - @open_issues_by_tracker[tracker].to_i), project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id, :status_id => 'c') %>
-          </td>
-          <td class="total">
-            <%= link_to @total_issues_by_tracker[tracker].to_i, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id, :status_id => '*') %>
-          </td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-    <% end %>
-    <p>
-      <%= link_to l(:label_issue_view_all), project_issues_path(@project, :set_filter => 1) %>
-      | <%= link_to l(:field_summary), project_issues_report_path(@project) %>
-      <% if User.current.allowed_to?(:view_calendar, @project, :global => true) %>
-        | <%= link_to l(:label_calendar), project_calendar_path(@project) %>
-      <% end %>
-      <% if User.current.allowed_to?(:view_gantt, @project, :global => true) %>
-        | <%= link_to l(:label_gantt), project_gantt_path(@project) %>
-      <% end %>
-    </p>
-  </div>
-  <% end %>
-
-  <% if User.current.allowed_to?(:view_time_entries, @project) %>
-  <div class="spent_time box">
-    <h3 class="icon icon-time"><%= l(:label_time_tracking) %></h3>
-    <ul>
-      <% if @total_estimated_hours.present? %>
-        <li><%= l(:field_estimated_hours) %>: <%= l_hours(@total_estimated_hours) %>
-      <% end %>
-      <% if @total_hours.present? %>
-          <li><%= l(:label_spent_time) %>: <%= l_hours(@total_hours) %>
-      <% end %>
-    </ul>
-    <p>
-    <% if User.current.allowed_to?(:log_time, @project) %>
-      <%= link_to l(:button_log_time), new_project_time_entry_path(@project) %> |
-    <% end %>
-    <%= link_to(l(:label_details), project_time_entries_path(@project)) %> |
-    <%= link_to(l(:label_report), report_project_time_entries_path(@project)) %>
-    </p>
-  </div>
-<% end %>
-  <%= call_hook(:view_projects_show_left, :project => @project) %>
-</div>
-
-<div class="splitcontentright">
-  <% if @news.any? && authorize_for('news', 'index') %>
-  <div class="news box">
-    <h3 class="icon icon-news"><%=l(:label_news_latest)%></h3>
-    <%= render :partial => 'news/news', :collection => @news %>
-    <p><%= link_to l(:label_news_view_all), project_news_index_path(@project) %></p>
-  </div>
-  <% end %>
-
-  <%= render :partial => 'members_box' %>
-
-  <% if @subprojects.any? %>
-  <div class="projects box">
-    <h3 class="icon icon-projects"><%=l(:label_subproject_plural)%></h3>
-	<ul class="subprojects">
-	  <% @subprojects.each do |project| %>
-	  <li><%= link_to(project.name, project_path(project), :class => project.css_classes).html_safe %></li>
-	  <% end %> 
-    </ul>
-  </div>
-  <% end %>
-
-  <%= call_hook(:view_projects_show_right, :project => @project) %>
-</div>
-</div>
-
-<% content_for :sidebar do %>
-  <%= call_hook(:view_projects_show_sidebar_bottom, :project => @project) %>
-<% end %>
-
-<% content_for :header_tags do %>
-<%= auto_discovery_link_tag(:atom, {:controller => 'activities', :action => 'index', :id => @project, :format => 'atom', :key => User.current.atom_key}) %>
-<% end %>
-
-<% html_title(l(:label_overview)) -%>
+<%
+  ZAppEngine.start_capture_requested_assets
+  override = ViewOverride.project_overview
+                         .active_instance
+                         .select { |vo| vo.matches?(project: @project) }
+  if override.any?
+    atp_log("HIER more than one matching override") if override.length > 1
+    snippet = override.first.vo_code_snippet
+    begin
+      result = render_snippet(snippet, { view_override: override.first })
+    rescue => e
+      atp_log "Override exception: project ##{@project.id}"
+      atp_log "Override exception: controller #{controller_name}"
+      atp_log "Override exception: action #{action_name}"
+      raise
+    end
+  end
+  to_render = result.present? ? result : (render partial: 'original_show')
+%>
+<%= render partial: 'z_app_engine/requested_assets' %>
+<%= to_render %>


### PR DESCRIPTION
Replace the Redmine view for Issue & Project with ZAppEngine & render Redmine's view as a fallback.