### PR TITLE
feat: Remove autologin feature, avoid storage of session tokens inside DB on redis usage

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -37,7 +37,6 @@ class Token < ActiveRecord::Base
   end
 
   add_action :api,       max_instances: 1,  validity_time: nil
-  add_action :autologin, max_instances: 10, validity_time: Proc.new {Setting.autologin.to_i.days}
   add_action :feeds,     max_instances: 1,  validity_time: nil
   add_action :recovery,  max_instances: 1,  validity_time: Proc.new {Token.validity_time}
   add_action :register,  max_instances: 1,  validity_time: Proc.new {Token.validity_time}

--- a/app/views/account/login.html.erb
+++ b/app/views/account/login.html.erb
@@ -3,20 +3,16 @@
 <div id="login-form">
   <%= form_tag(signin_path, onsubmit: 'return keepAnchorOnSignIn(this);') do %>
   <%= back_url_hidden_field_tag %>
-  
+
   <label for="username"><%=l(:field_login)%></label>
   <%= text_field_tag 'username', params[:username], :tabindex => '1' %>
-  
+
   <label for="password">
     <%=l(:field_password)%>
     <%= link_to l(:label_password_lost), lost_password_path, :class => "lost_password" if Setting.lost_password? %>
   </label>
   <%= password_field_tag 'password', nil, :tabindex => '2' %>
-  
-  <% if Setting.autologin? %>
-    <label for="autologin"><%= check_box_tag 'autologin', 1, false, :tabindex => 4 %> <%= l(:label_stay_logged_in) %></label>
-  <% end %>
-  
+
   <input type="submit" name="login" value="<%=l(:button_login)%>" tabindex="5" id="login-submit" />
   <% end %>
 </div>

--- a/app/views/settings/_authentication.html.erb
+++ b/app/views/settings/_authentication.html.erb
@@ -6,8 +6,6 @@
   <em class="info"><%= t(:text_login_required_html, anonymous_role_path: edit_role_path(Role.anonymous)) %></em>
 </p>
 
-<p><%= setting_select :autologin, [[l(:label_disabled), 0]] + [1, 7, 30, 365].collect{|days| [l('datetime.distance_in_words.x_days', :count => days), days.to_s]} %></p>
-
 <p><%= setting_select :self_registration, [[l(:label_disabled), "0"],
                                            [l(:label_registration_activation_by_email), "1"],
                                            [l(:label_registration_manual_activation), "2"],

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -75,14 +75,6 @@ default:
   # attachments_storage_path: D:/redmine/files
   attachments_storage_path:
 
-  # Configuration of the autologin cookie.
-  # autologin_cookie_name: the name of the cookie (default: autologin)
-  # autologin_cookie_path: the cookie path (default: /)
-  # autologin_cookie_secure: true sets the cookie secure flag (default: false)
-  autologin_cookie_name:
-  autologin_cookie_path:
-  autologin_cookie_secure:
-
   # Configuration of SCM executable command.
   #
   # Absolute path (e.g. /usr/local/bin/hg) or command name (e.g. hg.exe, bzr.exe)

--- a/db/migrate/20231127165403_remove_autologin_tokens.rb
+++ b/db/migrate/20231127165403_remove_autologin_tokens.rb
@@ -1,0 +1,10 @@
+class RemoveAutologinTokens < ActiveRecord::Migration[4.2]
+  def up
+    say_with_time "Deleting autologin tokens, this may take some time..." do
+      Token.where(:action => 'autologin').delete_all
+    end
+  end
+
+  def down
+  end
+end

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -128,7 +128,6 @@ pre, code {font-family: Consolas, Menlo, "Liberation Mono", Courier, monospace;}
 
 #login-form {margin:5em auto 2em auto; padding:20px; width:340px; border:1px solid #FDBF3B; background-color:#FFEBC1; border-radius:4px; box-sizing: border-box;}
 #login-form label {display:block; margin-bottom:5px; font-weight:bold;}
-#login-form label[for=autologin] {font-weight:normal;}
 #login-form input {height: 29px;}
 #login-form input[type=text], #login-form input[type=password], #login-form input[type=submit] {display: block; width: 100%;}
 #login-form input[type=text], #login-form input[type=password] {margin-bottom: 15px;}


### PR DESCRIPTION
* Remove the problematic feature of autologin entirely (security)
* Avoid the storage of tokens inside the database if redis is used as a session store