### PR TITLE
fix: Avoid session tokens inside the database

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -174,6 +174,7 @@ class ApplicationController < ActionController::Base
   def logout_user
     if User.current.logged?
       User.current.delete_session_token(session[:tk])
+      session.delete(:tk)
       self.logged_user = nil
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -436,7 +436,7 @@ class User < Principal
   # Generates a new session token and returns its value
   def generate_session_token
     # shortcut for redis sessions, just generate a random id
-    return Redmine::Utils.random_hex(20) if self.redis_session_store?
+    return Redmine::Utils.random_hex(20) if User.redis_session_store?
 
     token = Token.create!(:user_id => id, :action => 'session')
     token.value
@@ -444,7 +444,7 @@ class User < Principal
 
   def delete_session_token(value)
     # shortcut for redis sessions, nothing to do
-    return if self.redis_session_store?
+    return if User.redis_session_store?
 
     Token.where(:user_id => id, :action => 'session', :value => value).delete_all
   end


### PR DESCRIPTION
Remove the token from the session and make the proper static function calls to detect the redis session store