### PR TITLE
fix: Handle session timeout and lifetime properly for redis store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,12 +82,14 @@ class ApplicationController < ActionController::Base
   end
 
   def session_expired?
-    ! User.verify_session_token(session[:user_id], session[:tk])
+    ! User.verify_session_token(session)
   end
 
   def start_user_session(user)
     session[:user_id] = user.id
     session[:tk] = user.generate_session_token
+    session[:created_on] = Time.now
+    session[:updated_on] = Time.now
     if user.must_change_password?
       session[:pwd] = '1'
     end
@@ -175,6 +177,8 @@ class ApplicationController < ActionController::Base
     if User.current.logged?
       User.current.delete_session_token(session[:tk])
       session.delete(:tk)
+      session.delete(:created_on)
+      session.delete(:updated_on)
       self.logged_user = nil
     end
   end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -139,10 +139,10 @@ module SettingsHelper
 
   def session_lifetime_options
     options = [[l(:label_disabled), 0]]
-    options += [4, 8, 12].map do |hours|
+    options += [1, 2, 4, 8, 12].map do |hours|
       [l('datetime.distance_in_words.x_hours', :count => hours), (hours * 60).to_s]
     end
-    options += [1, 7, 30, 60, 365].map do |days|
+    options += [1, 2, 5, 7, 14, 30].map do |days|
       [l('datetime.distance_in_words.x_days', :count => days), (days * 24 * 60).to_s]
     end
     options
@@ -150,6 +150,9 @@ module SettingsHelper
 
   def session_timeout_options
     options = [[l(:label_disabled), 0]]
+    options += [5, 10, 15, 20, 30, 45].map do |minutes|
+      [l('datetime.distance_in_words.x_minutes', :count => minutes), minutes.to_s]
+    end
     options += [1, 2, 4, 8, 12, 24, 48].map do |hours|
       [l('datetime.distance_in_words.x_hours', :count => hours), (hours * 60).to_s]
     end


### PR DESCRIPTION
* fix: session admin parameters were ignored in the case the store was redis
* fix: apply timeout and lifetime correctly
* fix: adapted the possible settings to be able to conform with our more secure policies

NB: the redis expiration time has to be time to be greater than the lifetime
