### PR TITLE
fix: Allow view overrides to work without ZAppEngine running

### DIFF
--- a/app/views/issues/edit.html.erb
+++ b/app/views/issues/edit.html.erb
@@ -1,13 +1,13 @@
 <!-- to support view override using hooks -->
 <% call_hook(:view_issues_edit_view_override) %>
 
-<% if @view_issues_edit_view_override[:assets].present? %>
+<% if @view_issues_edit_view_override && @view_issues_edit_view_override[:assets].present? %>
   <% @view_issues_edit_view_override[:assets].each do |hook_assets| %>
     <%= hook_assets.html_safe %>
   <% end %>
 <% end %>
 
-<% if @view_issues_edit_view_override[:content].present? %>
+<% if @view_issues_edit_view_override && @view_issues_edit_view_override[:content].present? %>
   <%= @view_issues_edit_view_override[:content] %>
 <% else %>
   <h2><%= "#{@issue.tracker_was} ##{@issue.id}" %></h2>

--- a/app/views/issues/edit.html.erb
+++ b/app/views/issues/edit.html.erb
@@ -1,13 +1,13 @@
 <!-- to support view override using hooks -->
 <% call_hook(:view_issues_edit_view_override) %>
 
-<% if @view_issues_edit_view_override && @view_issues_edit_view_override[:assets].present? %>
+<% if @view_issues_edit_view_override&.dig(:assets).present? %>
   <% @view_issues_edit_view_override[:assets].each do |hook_assets| %>
     <%= hook_assets.html_safe %>
   <% end %>
 <% end %>
 
-<% if @view_issues_edit_view_override && @view_issues_edit_view_override[:content].present? %>
+<% if @view_issues_edit_view_override&.dig(:content).present? %>
   <%= @view_issues_edit_view_override[:content] %>
 <% else %>
   <h2><%= "#{@issue.tracker_was} ##{@issue.id}" %></h2>

--- a/app/views/issues/new.html.erb
+++ b/app/views/issues/new.html.erb
@@ -1,13 +1,13 @@
 <!-- to support view override using hooks -->
 <% call_hook(:view_issues_new_view_override) %>
 
-<% if @view_issues_new_view_override && @view_issues_new_view_override[:assets].present? %>
+<% if @view_issues_new_view_override&.dig(:assets).present? %>
   <% @view_issues_new_view_override[:assets].each do |hook_assets| %>
     <%= hook_assets.html_safe %>
   <% end %>
 <% end %>
 
-<% if @view_issues_new_view_override && @view_issues_new_view_override[:content].present? %>
+<% if @view_issues_new_view_override&.dig(:content).present? %>
   <%= @view_issues_new_view_override[:content] %>
 <% else %>
   <%= title l(:label_issue_new) %>

--- a/app/views/issues/new.html.erb
+++ b/app/views/issues/new.html.erb
@@ -1,12 +1,13 @@
 <!-- to support view override using hooks -->
 <% call_hook(:view_issues_new_view_override) %>
-<% if @view_issues_new_view_override[:assets].present? %>
+
+<% if @view_issues_new_view_override && @view_issues_new_view_override[:assets].present? %>
   <% @view_issues_new_view_override[:assets].each do |hook_assets| %>
     <%= hook_assets.html_safe %>
   <% end %>
 <% end %>
 
-<% if @view_issues_new_view_override[:content].present? %>
+<% if @view_issues_new_view_override && @view_issues_new_view_override[:content].present? %>
   <%= @view_issues_new_view_override[:content] %>
 <% else %>
   <%= title l(:label_issue_new) %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,13 +1,13 @@
 <!-- to support view override using hooks -->
 <% call_hook(:view_issues_show_view_override, issue: @issue, project: @project) %>
 
-<% if @view_issues_show_view_override[:assets].present? %>
+<% if @view_issues_show_view_override && @view_issues_show_view_override[:assets].present? %>
   <% @view_issues_show_view_override[:assets].each do |hook_assets| %>
     <%= hook_assets.html_safe %>
   <% end %>
 <% end %>
 
-<% if @view_issues_show_view_override[:content].present? %>
+<% if @view_issues_show_view_override && @view_issues_show_view_override[:content].present? %>
   <%= @view_issues_show_view_override[:content].html_safe %>
 <% else %>
 <%= render :partial => 'action_menu' %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,13 +1,13 @@
 <!-- to support view override using hooks -->
 <% call_hook(:view_issues_show_view_override, issue: @issue, project: @project) %>
 
-<% if @view_issues_show_view_override && @view_issues_show_view_override[:assets].present? %>
+<% if @view_issues_show_view_override&.dig(:assets).present? %>
   <% @view_issues_show_view_override[:assets].each do |hook_assets| %>
     <%= hook_assets.html_safe %>
   <% end %>
 <% end %>
 
-<% if @view_issues_show_view_override && @view_issues_show_view_override[:content].present? %>
+<% if @view_issues_show_view_override&.dig(:content).present? %>
   <%= @view_issues_show_view_override[:content].html_safe %>
 <% else %>
 <%= render :partial => 'action_menu' %>


### PR DESCRIPTION
Add safeguards in case the variable is not defined at all