### PR TITLE
feat: Translatable roles, trackers, issue statuses, custom fields, enumerations (i18n)

### DIFF
--- a/app/controllers/enumerations_controller.rb
+++ b/app/controllers/enumerations_controller.rb
@@ -110,6 +110,6 @@ class EnumerationsController < ApplicationController
   def enumeration_params
     # can't require enumeration on #new action
     cf_ids = @enumeration.available_custom_fields.map {|c| c.multiple? ? {c.id.to_s => []} : c.id.to_s}
-    params.permit(:enumeration => [:name, :active, :is_default, :position, :custom_field_values => cf_ids])[:enumeration]
+    params.permit(:enumeration => [:name, :active, :is_default, :position, :custom_field_values => cf_ids, i18n: {}])[:enumeration]
   end
 end

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -104,7 +104,7 @@ module CustomFieldsHelper
   def custom_field_name_tag(custom_field)
     title = custom_field.description.presence
     css = title ? "field-description" : nil
-    content_tag 'span', custom_field.name, :title => title, :class => css
+    content_tag 'span', custom_field.i18n_name, :title => title, :class => css
   end
 
   # Return custom field label tag

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -309,7 +309,7 @@ module IssuesHelper
 
   def trackers_options_for_select(issue)
     trackers = trackers_for_select(issue)
-    trackers.collect {|t| [t.name, t.id]}
+    trackers.collect {|t| [t.i18n_name, t.id]}
   end
 
   def trackers_for_select(issue)

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -23,6 +23,7 @@ module SettingsHelper
       [
         {:name => 'general', :partial => 'settings/general', :label => :label_general},
         {:name => 'display', :partial => 'settings/display', :label => :label_display},
+        {:name => 'language', :partial => 'settings/language', :label => :label_language},
         {:name => 'authentication', :partial => 'settings/authentication',
          :label => :label_authentication},
         {:name => 'api', :partial => 'settings/api', :label => :label_api},

--- a/app/helpers/workflows_helper.rb
+++ b/app/helpers/workflows_helper.rb
@@ -38,7 +38,7 @@ module WorkflowsHelper
       all_tag_options[:style] = "display:none;"
     end
     option_tags << content_tag('option', l(:label_all), all_tag_options)
-    option_tags << options_from_collection_for_select(objects, "id", "name", selected)
+    option_tags << options_from_collection_for_select(objects, "id", "i18n_name", selected)
     select_tag name, option_tags, {:multiple => multiple}.merge(options)
   end
 

--- a/app/models/concerns/translatable_attributes.rb
+++ b/app/models/concerns/translatable_attributes.rb
@@ -1,0 +1,20 @@
+module TranslatableAttributes
+  extend ActiveSupport::Concern
+
+  included do
+    store :i18n, coder: JSON
+  end
+
+  module ClassMethods
+    def i18n(*attr_names)
+      attr_names.each do |attr_name|
+        define_method :"i18n_#{attr_name}" do
+          return self.send(attr_name) if self.i18n.blank?
+
+          locale = User.current.language.to_s
+          self.i18n&.dig(attr_name, locale) || self.send(attr_name)
+        end
+      end
+    end
+  end
+end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -31,6 +31,7 @@ class CustomField < ActiveRecord::Base
                           :foreign_key => "custom_field_id"
   acts_as_positioned
   serialize :possible_values
+  store :i18n, coder: JSON
   store :format_store
 
   validates_presence_of :name, :field_format
@@ -100,7 +101,8 @@ class CustomField < ActiveRecord::Base
     'user_role',
     'version_status',
     'extensions_allowed',
-    'full_width_layout')
+    'full_width_layout',
+    'i18n')
 
   def copy_from(arg, options={})
     return if arg.blank?
@@ -341,6 +343,16 @@ class CustomField < ActiveRecord::Base
 
   def css_classes
     "#{field_format}_cf cf_#{id}"
+  end
+
+  # Add translated attributes here and in the edit view
+  %i[name].each do |attr_name|
+    define_method :"i18n_#{attr_name}" do
+      return send(attr_name) if i18n.blank?
+
+      locale = User.current.language.to_s
+      i18n&.dig(attr_name, locale) || send(attr_name)
+    end
   end
 
   protected

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -20,6 +20,7 @@
 class CustomField < ActiveRecord::Base
   include Redmine::SafeAttributes
   include Redmine::SubclassFactory
+  include TranslatableAttributes
 
   has_many :enumerations,
            lambda {order(:position)},
@@ -33,6 +34,8 @@ class CustomField < ActiveRecord::Base
   serialize :possible_values
   store :i18n, coder: JSON
   store :format_store
+
+  i18n :name
 
   validates_presence_of :name, :field_format
   validates_uniqueness_of :name, :scope => :type, :case_sensitive => true
@@ -73,6 +76,7 @@ class CustomField < ActiveRecord::Base
       where(:visible => true)
     end
   end)
+
   def visible_by?(project, user=User.current)
     visible? || user.admin?
   end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -32,7 +32,6 @@ class CustomField < ActiveRecord::Base
                           :foreign_key => "custom_field_id"
   acts_as_positioned
   serialize :possible_values
-  store :i18n, coder: JSON
   store :format_store
 
   i18n :name
@@ -347,16 +346,6 @@ class CustomField < ActiveRecord::Base
 
   def css_classes
     "#{field_format}_cf cf_#{id}"
-  end
-
-  # Add translated attributes here and in the edit view
-  %i[name].each do |attr_name|
-    define_method :"i18n_#{attr_name}" do
-      return send(attr_name) if i18n.blank?
-
-      locale = User.current.language.to_s
-      i18n&.dig(attr_name, locale) || send(attr_name)
-    end
   end
 
   protected

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -38,7 +38,6 @@ class Enumeration < ActiveRecord::Base
   validates_presence_of :name
   validates_uniqueness_of :name, :scope => [:type, :project_id], :case_sensitive => true
   validates_length_of :name, :maximum => 30
-  store :i18n, coder: JSON
 
   scope :shared, lambda {where(:project_id => nil)}
   scope :sorted, lambda {order(:position)}
@@ -133,16 +132,6 @@ class Enumeration < ActiveRecord::Base
   def self.same_active_state?(new, previous)
     new = (new == "1" ? true : false)
     return new == previous
-  end
-
-  # Add translated attributes here and in the edit view
-  %i[name].each do |attr_name|
-    define_method :"i18n_#{attr_name}" do
-      return send(attr_name) if i18n.blank?
-
-      locale = User.current.language.to_s
-      i18n&.dig(attr_name, locale) || send(attr_name)
-    end
   end
 
   private

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -35,6 +35,7 @@ class Enumeration < ActiveRecord::Base
   validates_presence_of :name
   validates_uniqueness_of :name, :scope => [:type, :project_id], :case_sensitive => true
   validates_length_of :name, :maximum => 30
+  store :i18n, coder: JSON
 
   scope :shared, lambda {where(:project_id => nil)}
   scope :sorted, lambda {order(:position)}
@@ -129,6 +130,16 @@ class Enumeration < ActiveRecord::Base
   def self.same_active_state?(new, previous)
     new = (new == "1" ? true : false)
     return new == previous
+  end
+
+  # Add translated attributes here and in the edit view
+  %i[name].each do |attr_name|
+    define_method :"i18n_#{attr_name}" do
+      return send(attr_name) if i18n.blank?
+
+      locale = User.current.language.to_s
+      i18n&.dig(attr_name, locale) || send(attr_name)
+    end
   end
 
   private

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -19,6 +19,7 @@
 
 class Enumeration < ActiveRecord::Base
   include Redmine::SubclassFactory
+  include TranslatableAttributes
 
   default_scope lambda {order(:position)}
 
@@ -31,6 +32,8 @@ class Enumeration < ActiveRecord::Base
   before_destroy :check_integrity
   before_save    :check_default
   after_save     :update_children_name
+
+  i18n :name
 
   validates_presence_of :name
   validates_uniqueness_of :name, :scope => [:type, :project_id], :case_sensitive => true

--- a/app/models/issue_status.rb
+++ b/app/models/issue_status.rb
@@ -35,7 +35,6 @@ class IssueStatus < ActiveRecord::Base
   validates_uniqueness_of :name, :case_sensitive => true
   validates_length_of :name, :maximum => 30
   validates_inclusion_of :default_done_ratio, :in => 0..100, :allow_nil => true
-  store :i18n, coder: JSON
 
   scope :sorted, lambda {order(:position)}
   scope :named, lambda {|arg| where("LOWER(#{table_name}.name) = LOWER(?)", arg.to_s.strip)}
@@ -91,16 +90,6 @@ class IssueStatus < ActiveRecord::Base
   end
 
   def to_s; name end
-
-  # Add translated attributes here and in the edit view
-  %i[name].each do |attr_name|
-    define_method :"i18n_#{attr_name}" do
-      return send(attr_name) if i18n.blank?
-
-      locale = User.current.language.to_s
-      i18n&.dig(attr_name, locale) || send(attr_name)
-    end
-  end
 
   private
 

--- a/app/models/issue_status.rb
+++ b/app/models/issue_status.rb
@@ -19,11 +19,14 @@
 
 class IssueStatus < ActiveRecord::Base
   include Redmine::SafeAttributes
+  include TranslatableAttributes
 
   before_destroy :check_integrity
   has_many :workflows, :class_name => 'WorkflowTransition', :foreign_key => "old_status_id"
   has_many :workflow_transitions_as_new_status, :class_name => 'WorkflowTransition', :foreign_key => "new_status_id"
   acts_as_positioned
+
+  i18n :name
 
   after_update :handle_is_closed_change
   before_destroy :delete_workflow_rules

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -79,7 +79,6 @@ class Role < ActiveRecord::Base
 
   serialize :permissions, ::Role::PermissionsAttributeCoder
   store :settings, :accessors => [:permissions_all_trackers, :permissions_tracker_ids]
-  store :i18n, coder: JSON
 
   validates_presence_of :name
   validates_uniqueness_of :name, :case_sensitive => true
@@ -296,16 +295,6 @@ class Role < ActiveRecord::Base
   # it will be created on the fly.
   def self.anonymous
     find_or_create_system_role(BUILTIN_ANONYMOUS, 'Anonymous')
-  end
-
-  # Add translated attributes here and in the edit view
-  %i[name].each do |attr_name|
-    define_method :"i18n_#{attr_name}" do
-      return send(attr_name) if i18n.blank?
-
-      locale = User.current.language.to_s
-      i18n&.dig(attr_name, locale) || send(attr_name)
-    end
   end
 
   private

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -19,6 +19,7 @@
 
 class Role < ActiveRecord::Base
   include Redmine::SafeAttributes
+  include TranslatableAttributes
 
   # Custom coder for the permissions attribute that should be an
   # array of symbols. Rails 3 uses Psych which can be *unbelievably*
@@ -52,6 +53,8 @@ class Role < ActiveRecord::Base
     ['all', :label_users_visibility_all],
     ['members_of_visible_projects', :label_users_visibility_members_of_visible_projects]
   ]
+
+  i18n :name
 
   scope :sorted, lambda {order(:builtin, :position)}
   scope :givable, lambda {order(:position).where(:builtin => 0)}

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -76,6 +76,7 @@ class Role < ActiveRecord::Base
 
   serialize :permissions, ::Role::PermissionsAttributeCoder
   store :settings, :accessors => [:permissions_all_trackers, :permissions_tracker_ids]
+  store :i18n, coder: JSON
 
   validates_presence_of :name
   validates_uniqueness_of :name, :case_sensitive => true
@@ -104,7 +105,8 @@ class Role < ActiveRecord::Base
     'managed_role_ids',
     'permissions',
     'permissions_all_trackers',
-    'permissions_tracker_ids'
+    'permissions_tracker_ids',
+    'i18n'
   )
 
   # Copies attributes from another role, arg can be an id or a Role
@@ -291,6 +293,16 @@ class Role < ActiveRecord::Base
   # it will be created on the fly.
   def self.anonymous
     find_or_create_system_role(BUILTIN_ANONYMOUS, 'Anonymous')
+  end
+
+  # Add translated attributes here and in the edit view
+  %i[name].each do |attr_name|
+    define_method :"i18n_#{attr_name}" do
+      return send(attr_name) if i18n.blank?
+
+      locale = User.current.language.to_s
+      i18n&.dig(attr_name, locale) || send(attr_name)
+    end
   end
 
   private

--- a/app/models/tracker.rb
+++ b/app/models/tracker.rb
@@ -47,8 +47,6 @@ class Tracker < ActiveRecord::Base
   validates_length_of :name, :maximum => 30
   validates_length_of :description, :maximum => 255
 
-  store :i18n, coder: JSON
-
   scope :sorted, lambda {order(:position)}
   scope :named, lambda {|arg| where("LOWER(#{table_name}.name) = LOWER(?)", arg.to_s.strip)}
 
@@ -164,16 +162,6 @@ class Tracker < ActiveRecord::Base
       trackers.uniq.map(&:core_fields).reduce(:|)
     else
       CORE_FIELDS.dup
-    end
-  end
-
-  # Add translated attributes here and in the edit view
-  %i[name].each do |attr_name|
-    define_method :"i18n_#{attr_name}" do
-      return send(attr_name) if i18n.blank?
-
-      locale = User.current.language.to_s
-      i18n&.dig(attr_name, locale) || send(attr_name)
     end
   end
 

--- a/app/models/tracker.rb
+++ b/app/models/tracker.rb
@@ -19,6 +19,7 @@
 
 class Tracker < ActiveRecord::Base
   include Redmine::SafeAttributes
+  include TranslatableAttributes
 
   CORE_FIELDS_UNDISABLABLE = %w(project_id tracker_id subject priority_id is_private).freeze
   # Fields that can be disabled
@@ -27,6 +28,8 @@ class Tracker < ActiveRecord::Base
     %w(assigned_to_id category_id fixed_version_id parent_issue_id
        start_date due_date estimated_hours done_ratio description).freeze
   CORE_FIELDS_ALL = (CORE_FIELDS_UNDISABLABLE + CORE_FIELDS).freeze
+
+  i18n :name
 
   before_destroy :check_integrity
   belongs_to :default_status, :class_name => 'IssueStatus'

--- a/app/models/tracker.rb
+++ b/app/models/tracker.rb
@@ -44,6 +44,8 @@ class Tracker < ActiveRecord::Base
   validates_length_of :name, :maximum => 30
   validates_length_of :description, :maximum => 255
 
+  store :i18n, coder: JSON
+
   scope :sorted, lambda {order(:position)}
   scope :named, lambda {|arg| where("LOWER(#{table_name}.name) = LOWER(?)", arg.to_s.strip)}
 
@@ -78,7 +80,8 @@ class Tracker < ActiveRecord::Base
     'position',
     'custom_field_ids',
     'project_ids',
-    'description')
+    'description',
+    'i18n')
 
   def copy_from(arg, options={})
     return if arg.blank?
@@ -158,6 +161,16 @@ class Tracker < ActiveRecord::Base
       trackers.uniq.map(&:core_fields).reduce(:|)
     else
       CORE_FIELDS.dup
+    end
+  end
+
+  # Add translated attributes here and in the edit view
+  %i[name].each do |attr_name|
+    define_method :"i18n_#{attr_name}" do
+      return send(attr_name) if i18n.blank?
+
+      locale = User.current.language.to_s
+      i18n&.dig(attr_name, locale) || send(attr_name)
     end
   end
 

--- a/app/views/common/_translations.erb
+++ b/app/views/common/_translations.erb
@@ -1,7 +1,9 @@
 <%# requires a :i18n store attribute %>
+<% translated_languages = Setting.translated_language_ids %>
+<% if translated_languages.present? %>
 <fieldset class="box tabular"><legend><%= l(:label_translated_language) %></legend>
   <%= f.fields_for :i18n do |fi| %>
-    <% Setting.translated_language_ids.each do |locale| %>
+    <% translated_languages.each do |locale| %>
       <p>
       <%= fi.text_field "#{translated_field}[#{locale}]",
         value: f.object.i18n&.dig(translated_field, locale),
@@ -11,3 +13,4 @@
     <% end %>
   <% end %>
 </fieldset>
+<% end %>

--- a/app/views/common/_translations.erb
+++ b/app/views/common/_translations.erb
@@ -1,0 +1,13 @@
+<%# requires a :i18n store attribute %>
+<fieldset class="box tabular"><legend><%= l(:label_translated_language) %></legend>
+  <%= f.fields_for :i18n do |fi| %>
+    <% Setting.translated_language_ids.each do |locale| %>
+      <p>
+      <%= fi.text_field "#{translated_field}[#{locale}]",
+        value: f.object.i18n&.dig(translated_field, locale),
+        label: ll(locale, :general_lang_name),
+        :size => 50 %>
+      </p>
+    <% end %>
+  <% end %>
+</fieldset>

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -5,6 +5,9 @@
 <div class="box tabular">
 <p><%= f.select :field_format, custom_field_formats_for_select(@custom_field), {}, :disabled => !@custom_field.new_record? %></p>
 <p><%= f.text_field :name, :size => 50, :required => true %></p>
+
+<%= render :partial => 'common/translations', :locals => { translated_field: :name, :f => f } %>
+
 <p><%= f.text_area :description, :rows => 7 %></p>
 
 <% if @custom_field.format.multiple_supported %>

--- a/app/views/custom_fields/_index.html.erb
+++ b/app/views/custom_fields/_index.html.erb
@@ -13,7 +13,7 @@
   <% (@custom_fields_by_type[tab[:name]] || []).sort.each do |custom_field| -%>
     <% back_url = custom_fields_path(:tab => tab[:name]) %>
     <tr>
-      <td class="name"><%= link_to custom_field.name, edit_custom_field_path(custom_field) %></td>
+      <td class="name"><%= link_to custom_field.i18n_name, edit_custom_field_path(custom_field) %></td>
       <td><%= l(custom_field.format.label) %></td>
       <td><%= checked_image custom_field.is_required? %></td>
       <% if tab[:name] == 'IssueCustomField' %>

--- a/app/views/custom_fields/_visibility_by_role_selector.html.erb
+++ b/app/views/custom_fields/_visibility_by_role_selector.html.erb
@@ -13,7 +13,7 @@
   <% Role.givable.sorted.each do |role| %>
     <label class="block custom_field_role" style="padding-left:2em;">
       <%= check_box_tag 'custom_field[role_ids][]', role.id, role_ids.include?(role.id), :id => nil %>
-      <%= role.name %>
+      <%= role.i18n_name %>
     </label>
   <% end %>
   <%= hidden_field_tag 'custom_field[role_ids][]', '' %>

--- a/app/views/custom_fields/_visibility_by_tracker_selector.html.erb
+++ b/app/views/custom_fields/_visibility_by_tracker_selector.html.erb
@@ -6,7 +6,7 @@
                       tracker_ids.include?(tracker.id),
                       :id => "custom_field_tracker_ids_#{tracker.id}" %>
     <label class="no-css" for="custom_field_tracker_ids_<%=tracker.id%>">
-      <%= tracker.name %>
+      <%= tracker.i18n_name %>
     </label>
   <% end %>
   <%= hidden_field_tag "custom_field[tracker_ids][]", '' %>

--- a/app/views/enumerations/_form.html.erb
+++ b/app/views/enumerations/_form.html.erb
@@ -2,6 +2,7 @@
 
 <div class="box tabular">
   <p><%= f.text_field :name %></p>
+  <%= render :partial => 'common/translations', :locals => { translated_field: :name, :f => f } %>
   <p><%= f.check_box :active %></p>
   <p><%= f.check_box :is_default %></p>
 

--- a/app/views/enumerations/index.html.erb
+++ b/app/views/enumerations/index.html.erb
@@ -17,7 +17,7 @@
 </tr></thead>
 <% enumerations.each do |enumeration| %>
 <tr>
-    <td class="name"><%= link_to enumeration, edit_enumeration_path(enumeration) %></td>
+    <td class="name"><%= link_to enumeration.i18n_name, edit_enumeration_path(enumeration) %></td>
     <td class="tick"><%= checked_image enumeration.is_default? %></td>
     <td class="tick"><%= checked_image enumeration.active? %></td>
     <td class="buttons">

--- a/app/views/issue_statuses/_form.html.erb
+++ b/app/views/issue_statuses/_form.html.erb
@@ -2,6 +2,7 @@
 
 <div class="box tabular">
 <p><%= f.text_field :name, :required => true %></p>
+<%= render :partial => 'common/translations', :locals => { translated_field: :name, :f => f } %>
 <% if Issue.use_status_for_done_ratio? %>
   <p><%= f.select :default_done_ratio, ((0..10).to_a.collect {|r| ["#{r*10} %", r*10] }), :include_blank => true, :label => :field_done_ratio %></p>
 <% end %>

--- a/app/views/issue_statuses/index.html.erb
+++ b/app/views/issue_statuses/index.html.erb
@@ -18,7 +18,7 @@
   <tbody>
 <% for status in @issue_statuses %>
   <tr>
-  <td class="name"><%= link_to status.name, edit_issue_status_path(status) %></td>
+  <td class="name"><%= link_to status.i18n_name, edit_issue_status_path(status) %></td>
   <% if Issue.use_status_for_done_ratio? %>
   <td><%= status.default_done_ratio %></td>
   <% end %>

--- a/app/views/issues/_attributes.html.erb
+++ b/app/views/issues/_attributes.html.erb
@@ -4,7 +4,7 @@
 <div class="splitcontentleft">
 <% if @issue.safe_attribute?('status_id') && @allowed_statuses.present? %>
 <p>
-  <%= f.select :status_id, (@allowed_statuses.collect {|p| [p.name, p.id]}), {:required => true},
+  <%= f.select :status_id, (@allowed_statuses.collect {|p| [p.i18n_name, p.id]}), {:required => true},
                 :onchange => "updateIssueFrom('#{escape_javascript(update_issue_form_path(@project, @issue))}', this)" %>
   <% if @issue.transition_warning %>
     <span class="icon-only icon-warning" title="<%= @issue.transition_warning %>"><%= @issue.transition_warning %></span>
@@ -16,7 +16,7 @@
 <% end %>
 
 <% if @issue.safe_attribute? 'priority_id' %>
-<p><%= f.select :priority_id, (@priorities.collect {|p| [p.name, p.id]}), {:required => true} %></p>
+<p><%= f.select :priority_id, (@priorities.collect {|p| [p.i18n_name, p.id]}), {:required => true} %></p>
 <% end %>
 
 <% if @issue.safe_attribute? 'assigned_to_id' %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -58,8 +58,8 @@
 
 <div class="attributes">
 <%= issue_fields_rows do |rows|
-  rows.left l(:field_status), @issue.status.name, :class => 'status'
-  rows.left l(:field_priority), @issue.priority.name, :class => 'priority'
+  rows.left l(:field_status), @issue.status.i18n_name, :class => 'status'
+  rows.left l(:field_priority), @issue.priority.i18n_name, :class => 'priority'
 
   unless @issue.disabled_core_fields.include?('assigned_to_id')
     rows.left l(:field_assigned_to), (@issue.assigned_to ? link_to_principal(@issue.assigned_to) : "-"), :class => 'assigned-to'
@@ -145,7 +145,7 @@ end %>
   <%= f.link_to 'PDF' %>
 <% end %>
 
-<% html_title "#{@issue.tracker.name} ##{@issue.id}: #{@issue.subject}" %>
+<% html_title "#{@issue.tracker.i18n_name} ##{@issue.id}: #{@issue.subject}" %>
 
 <% content_for :sidebar do %>
   <%= render :partial => 'issues/sidebar' %>

--- a/app/views/journals/diff.html.erb
+++ b/app/views/journals/diff.html.erb
@@ -8,4 +8,4 @@
               :onclick => 'if (document.referrer != "") {history.back(); return false;}') %>
 </p>
 
-<% html_title "#{@issue.tracker.name} ##{@issue.id}: #{@issue.subject}" %>
+<% html_title "#{@issue.tracker.i18n_name} ##{@issue.id}: #{@issue.subject}" %>

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -3,6 +3,7 @@
 <div class="box tabular">
   <% unless @role.builtin? %>
     <p><%= f.text_field :name, :required => true %></p>
+    <%= render :partial => 'common/translations', :locals => { translated_field: :name, :f => f } %>
     <p><%= f.check_box :assignable %></p>
   <% end %>
 

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -14,7 +14,7 @@
   <tbody>
 <% for role in @roles %>
   <tr class="<%= role.builtin? ? "builtin" : "givable" %>">
-  <td class="name"><%= content_tag(role.builtin? ? 'em' : 'span', link_to(role.name, edit_role_path(role))) %></td>
+  <td class="name"><%= content_tag(role.builtin? ? 'em' : 'span', link_to(role.i18n_name, edit_role_path(role))) %></td>
   <td>
     <% unless role.builtin? || role.workflow_rules.exists? %>
       <span class="icon icon-warning">

--- a/app/views/settings/_display.html.erb
+++ b/app/views/settings/_display.html.erb
@@ -3,12 +3,6 @@
 <div class="box tabular settings">
 <p><%= setting_select :ui_theme, Redmine::Themes.themes.collect {|t| [t.name, t.id]}, :blank => :label_default, :label => :label_theme %></p>
 
-<p><%= setting_select :default_language, lang_options_for_select(false) %></p>
-
-<p><%= setting_check_box :force_default_language_for_anonymous %></p>
-
-<p><%= setting_check_box :force_default_language_for_loggedin %></p>
-
 <p><%= setting_select :start_of_week, [[day_name(1),'1'], [day_name(6),'6'], [day_name(7),'7']], :blank => :label_language_based %></p>
 <% locale = User.current.language.blank? ? ::I18n.locale : User.current.language %>
 <p><%= setting_select :date_format, date_format_setting_options(locale), :blank => :label_language_based %></p>

--- a/app/views/settings/_language.erb
+++ b/app/views/settings/_language.erb
@@ -1,0 +1,19 @@
+<%= form_tag({:action => 'edit', :tab => 'language'}) do %>
+
+<% current_default_language = Setting.default_language %>
+
+<div class="box tabular settings">
+<p><%= setting_select :default_language, lang_options_for_select(false) %></p>
+
+<p><%= setting_check_box :force_default_language_for_anonymous %></p>
+
+<p><%= setting_check_box :force_default_language_for_loggedin %></p>
+
+<% locales = valid_languages.map { |lang| [ll(lang.to_s, :general_lang_name), lang.to_s] }.sort_by(&:last) %>
+
+<p><%= setting_multiselect :translated_language_ids, locales %></p>
+
+</div>
+
+<%= submit_tag l(:button_save) %>
+<% end %>

--- a/app/views/trackers/_form.html.erb
+++ b/app/views/trackers/_form.html.erb
@@ -5,6 +5,7 @@
 <div class="box tabular">
 <!--[form:tracker]-->
 <p><%= f.text_field :name, :required => true %></p>
+<%= render :partial => 'common/translations', :locals => { translated_field: :name, :f => f } %>
 <p><%= f.select :default_status_id,
         IssueStatus.sorted.map {|s| [s.name, s.id]},
         :include_blank => @tracker.default_status.nil?,

--- a/app/views/trackers/_form.html.erb
+++ b/app/views/trackers/_form.html.erb
@@ -7,7 +7,7 @@
 <p><%= f.text_field :name, :required => true %></p>
 <%= render :partial => 'common/translations', :locals => { translated_field: :name, :f => f } %>
 <p><%= f.select :default_status_id,
-        IssueStatus.sorted.map {|s| [s.name, s.id]},
+        IssueStatus.sorted.map {|s| [s.i18n_name, s.id]},
         :include_blank => @tracker.default_status.nil?,
         :required => true %>
 </p>
@@ -31,7 +31,7 @@
   <% @issue_custom_fields.each do |field| %>
     <label class="block">
       <%= check_box_tag 'tracker[custom_field_ids][]',field.id, @tracker.custom_fields.to_a.include?(field), :id => nil %>
-      <%= field.name %>
+      <%= field.i18n_name %>
     </label>
   <% end %>
 </p>

--- a/app/views/trackers/index.html.erb
+++ b/app/views/trackers/index.html.erb
@@ -16,8 +16,8 @@
   <tbody>
 <% for tracker in @trackers %>
   <tr>
-  <td class="name"><%= link_to tracker.name, edit_tracker_path(tracker) %></td>
-  <td><%= tracker.default_status.name %></td>
+  <td class="name"><%= link_to tracker.i18n_name, edit_tracker_path(tracker) %></td>
+  <td><%= tracker.default_status.i18n_name %></td>
   <td class="description"><%= tracker.description %></td>
   <td>
     <% unless tracker.workflow_rules.exists? %>

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -16,7 +16,7 @@
       <%= link_to_function('', "toggleCheckboxesBySelector('table.transitions-#{name} input[type=checkbox]:not(:disabled).new-status-#{new_status.id}')",
                            :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
                            :class => 'no-tooltip icon-only icon-checked') %>
-      <%= new_status.name %>
+      <%= new_status.i18n_name %>
     </td>
     <% end %>
   </tr>
@@ -31,7 +31,7 @@
                            :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
                            :class => 'no-tooltip icon-only icon-checked') %>
       <% if old_status %>
-        <% old_status_name = old_status.name %>
+        <% old_status_name = old_status.i18n_name %>
         <%= old_status_name %>
       <% else %>
         <% old_status_name = l(:label_issue_new) %>
@@ -40,7 +40,7 @@
     </td>
     <% for new_status in @statuses -%>
     <% checked = (old_status == new_status) || (transition_counts[[old_status, new_status]] > 0) %>
-    <td class="no-tooltip <%= checked ? 'enabled' : '' %>" title="<%= old_status_name %> &#187; <%= new_status.name %>">
+    <td class="no-tooltip <%= checked ? 'enabled' : '' %>" title="<%= old_status_name %> &#187; <%= new_status.i18n_name %>">
       <%= transition_tag transition_counts[[old_status, new_status]], old_status, new_status, name %>
     </td>
     <% end -%>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -10,7 +10,7 @@
     <th></th>
     <% @roles.each do |role| %>
     <th>
-        <%= content_tag(role.builtin? ? 'em' : 'span', role.name) %>
+        <%= content_tag(role.builtin? ? 'em' : 'span', role.i18n_name) %>
     </th>
     <% end %>
     </tr>

--- a/app/views/workflows/permissions.html.erb
+++ b/app/views/workflows/permissions.html.erb
@@ -46,7 +46,7 @@
         <td></td>
         <% for status in @statuses %>
         <td style="width:<%= 75 / @statuses.size %>%;">
-          <%= status.name %>
+          <%= status.i18n_name %>
         </td>
         <% end %>
       </tr>
@@ -81,7 +81,7 @@
         <% @custom_fields.each do |field| %>
         <tr>
           <td class="name">
-            <%= field.name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
+            <%= field.i18n_name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
           </td>
           <% for status in @statuses -%>
           <td class="<%= @permissions[status.id][field.id.to_s].try(:join, ' ') %>" title="<%= field.name %> (<%= status.name %>)">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -525,6 +525,8 @@ de:
   label_diff_side_by_side: nebeneinander
   label_disabled: gesperrt
   label_display: Anzeige
+  label_language: Sprache
+  label_translated_language: Übersetzte Sprache
   label_display_per_page: "Pro Seite: %{value}"
   label_display_used_statuses_only: Zeige nur Status an, die von diesem Tracker verwendet werden
   label_document: Dokument
@@ -1053,6 +1055,7 @@ de:
   setting_thumbnails_size: Größe der Vorschaubilder (in Pixeln)
   setting_time_format: Zeitformat
   setting_timespan_format: Format für Zeitspannen
+  setting_translated_language_ids: Übersetzte Sprachen
   setting_unsubscribe: Benutzern erlauben, das eigene Benutzerkonto zu löschen
   setting_user_format: Benutzer-Anzeigeformat
   setting_welcome_text: Willkommenstext

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -374,6 +374,7 @@ en-GB:
   setting_gantt_items_limit: Maximum number of items displayed on the gantt chart
   setting_issue_group_assignment: Allow ticket assignment to groups
   setting_default_issue_start_date_to_creation_date: Use current date as start date for new tickets
+  setting_translated_language_ids: Translated languages
 
   permission_add_project: Create project
   permission_add_subprojects: Create subprojects
@@ -757,6 +758,8 @@ en-GB:
   label_issue_watchers: Watchers
   label_example: Example
   label_display: Display
+  label_language: Language
+  label_translated_language: Translated language
   label_sort: Sort
   label_ascending: Ascending
   label_descending: Descending

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -504,6 +504,7 @@ en:
   setting_timelog_accept_0_hours: Accept time logs with 0 hours
   setting_timelog_max_hours_per_day: Maximum hours that can be logged per day and user
   setting_timelog_accept_future_dates: Accept time logs on future dates
+  setting_translated_language_ids: Translated languages
   setting_show_status_changes_in_mail_subject: Show status changes in ticket mail notifications subject
   setting_project_list_defaults: Projects list defaults
   setting_twofa: Two-factor authentication
@@ -967,6 +968,8 @@ en:
   label_wiki_page_watchers: Watchers
   label_example: Example
   label_display: Display
+  label_language: Language
+  label_translated_language: Translated language
   label_sort: Sort
   label_ascending: Ascending
   label_descending: Descending

--- a/config/locales/es-PA.yml
+++ b/config/locales/es-PA.yml
@@ -824,6 +824,7 @@ es-PA:
   button_create_and_continue: Crear y continuar
   text_custom_field_possible_values_info: 'Un valor en cada línea'
   label_display: Mostrar
+  label_language: Idioma
   field_editable: Modificable
   setting_repository_log_display_limit: Número máximo de revisiones mostradas en el archivo de trazas
   setting_file_max_size_displayed: Tamaño máximo de los archivos de texto mostrados

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -822,6 +822,7 @@ es:
   button_create_and_continue: Crear y continuar
   text_custom_field_possible_values_info: 'Un valor en cada línea'
   label_display: Mostrar
+  label_language: Idioma
   field_editable: Modificable
   setting_repository_log_display_limit: Número máximo de revisiones mostradas en el fichero de trazas
   setting_file_max_size_displayed: Tamaño máximo de los ficheros de texto mostrados

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -478,6 +478,7 @@ fr:
   setting_time_entry_list_defaults: Affichage par défaut de la liste des temps passés
   setting_timelog_accept_0_hours: Autoriser la saisie de temps avec 0 heure
   setting_timelog_max_hours_per_day: Maximum d'heures pouvant être saisies par un utilisateur sur un jour
+  setting_translated_language_ids: Langues traduites
 
   permission_add_project: Créer un projet
   permission_add_subprojects: Créer des sous-projets
@@ -903,6 +904,8 @@ fr:
   label_issue_watchers: Observateurs
   label_example: Exemple
   label_display: Affichage
+  label_language: Langue
+  label_translated_language: Langue traduite
   label_sort: Tri
   label_ascending: Croissant
   label_descending: Décroissant

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -106,6 +106,9 @@ force_default_language_for_anonymous:
   default: 0
 force_default_language_for_loggedin:
   default: 0
+translated_language_ids:
+  serialized: true
+  default:
 host_name:
   default: localhost:3000
 protocol:

--- a/db/migrate/20240307141702_add_i18n_fields.rb
+++ b/db/migrate/20240307141702_add_i18n_fields.rb
@@ -1,0 +1,17 @@
+class AddI18nFields < ActiveRecord::Migration[4.2]
+  def self.up
+    add_column(:custom_fields, "i18n", :text)
+    add_column(:enumerations, "i18n", :text)
+    add_column(:issue_statuses, "i18n", :text)
+    add_column(:roles, "i18n", :text)
+    add_column(:trackers, "i18n", :text)
+  end
+
+  def self.down
+    remove_column(:custom_fields, "i18n")
+    remove_column(:enumerations, "i18n")
+    remove_column(:issue_statuses, "i18n")
+    remove_column(:roles, "i18n")
+    remove_column(:trackers, "i18n")
+  end
+end


### PR DESCRIPTION
Prepares the ground for i18n:

* Shift all language settings into a new tab inside the admin settings:
![image](https://github.com/tools-aoeur/redmine/assets/261428/1081ab93-3b27-400c-869b-5d838aca912f)

* Add i18n field to custom_fields, enumerations, issue_statuses, roles and trackers. The i18n text field is expected to contain a json string with a hash of hashes
* `translated_language_ids` setting contains the array of locales to expect having a translation for the configured data

example of json string:

```json
{
  "name": {
    "en": "a custom field"
    "de": "ein benutzerdefiniertes Feld"
  }
}
```

The structure accounts for being able to add more columns to be translated as we progress (the first one being the name) but we will not want to add one i18n column for each column to translate. These translations could theoretically also get preloaded and cached. But perf considerations are very low prio. 

* Use the i18n names for admin views
* Use the i18n names for the issue views (show, edit)

**TODO**:

* [ ] add UI to edit the translation showing a warning for missing translations (`translated_language_ids` not present) and allowing to edit the name for each of the `translated_language_ids`. The JS code for handling this can generate the json so that the form basically handles a string (JSON) only.
* [ ] Uniqueness or other validations are not applied to the translated attribute. This is responsibility for the translator at the moment to pay attention to that by him/herself

The code to edit can be easily copied to the edit views for the models impacted ideally.
