### PR TITLE
fix: Remove `key` from the filter parameters list

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,7 +58,7 @@ module RedmineApp
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += %i[password passw secret token _key crypt salt certificate otp ssn key]
+    config.filter_parameters += %i[password passw secret token _key crypt salt certificate otp ssn]
 
     config.action_mailer.perform_deliveries = false
 


### PR DESCRIPTION
____________________________________________________________________

Your contributions to Redmine are welcome!

Please **open an issue on the [official website]** instead of sending pull requests.

Since the development of Redmine is not conducted on GitHub but on the [official website] and core developers are not monitoring the GitHub repo, pull requests might not get reviewed.

For more detail about how to contribute, please see the wiki page [Contribute] on the [official website].

[official website]: https://www.redmine.org/
[Contribute]: https://www.redmine.org/projects/redmine/wiki/Contribute
