### PR TITLE
fix: Set to_time_preserves_timezone for specs as it is in production

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,10 @@ end
 # load rails/redmine
 require_relative '../config/environment'
 
+# Rails 8.0 timezone preservation configuration
+# This setting ensures timezone offset preservation when converting to time
+ActiveSupport.to_time_preserves_timezone = true
+
 require Rails.root.join('test/object_helpers').expand_path(__FILE__)
 include ObjectHelpers # rubocop:disable Style/MixinUsage
 include Redmine::QuoteReply::Helper  # rubocop:disable Style/MixinUsage


### PR DESCRIPTION
This gets rid of noisy lines during test execution:

```
DEPRECATION WARNING: to_time will always preserve the timezone offset of the receiver
in Rails 8.0. To opt in to the new behavior, set `[ActiveSupport.to](http://activesupport.to/)_time_preserves_timezone = true`.
(called from Redmine::I18n#format_time at /workspaces/redmine/redmine/lib/redmine/i18n.rb:87)
```