### PR TITLE
Fix: Tooling, improve running tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,6 +10,10 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Rails 8.0 timezone preservation configuration
+  # This setting ensures timezone offset preservation when converting to time
+  ActiveSupport.to_time_preserves_timezone = true
+
   config.enable_reloading = false
   # config.action_view.cache_template_loading = true
 

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -118,6 +118,7 @@ namespace :test do
   task(:autoload) do |t|
     $: << "test"
     ENV["REDMINE_PLUGINS_DIRECTORY"] = "test/fixtures/plugins"
+    ENV["REDMINE_AUTOLOAD_TEST"] = "1"
     Rails::TestUnit::Runner.run_from_rake 'test', FileList['test/autoload/*_test.rb']
   end
   Rake::Task['test:autoload'].comment = "Run the plugin autoload tests"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,10 +18,6 @@ end
 # load rails/redmine
 require_relative '../config/environment'
 
-# Rails 8.0 timezone preservation configuration
-# This setting ensures timezone offset preservation when converting to time
-ActiveSupport.to_time_preserves_timezone = true
-
 require Rails.root.join('test/object_helpers').expand_path(__FILE__)
 include ObjectHelpers # rubocop:disable Style/MixinUsage
 include Redmine::QuoteReply::Helper  # rubocop:disable Style/MixinUsage

--- a/test/autoload/plugin_autoload_test.rb
+++ b/test/autoload/plugin_autoload_test.rb
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 require_relative '../test_helper'
 class Redmine::PluginAutoloadTest < ActiveSupport::TestCase
-  if ENV['REDMINE_PLUGINS_DIRECTORY']
+  if ENV['REDMINE_AUTOLOAD_TEST']
     def test_autoload
       assert_equal true, Object.const_defined?(:Foo)
     end


### PR DESCRIPTION
The deprecation warning still is output in the case of redmine core tests. Shifted the configuration setting into the test env. Moreover we need to use the `REDMINE_PLUGINS_DIRECTORY` for other purposes and that collides with it being used as a test guard (yielding always a failing test)