### PR TITLE
fix: Avoid LoadError exceptions at startup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,9 @@ gem "requestjs-rails", "~> 0.0.13"
 
 #  Ruby Standard Gems
 gem 'csv', '~> 3.3.2'
-gem 'net-imap', '~> 0.5.7'
-gem 'net-pop', '~> 0.1.2'
-gem 'net-smtp', '~> 0.5.0'
+gem 'net-imap', '~> 0.5.7', require: 'net/imap'
+gem 'net-pop', '~> 0.1.2', require: 'net/pop'
+gem 'net-smtp', '~> 0.5.0', require: 'net/smtp'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:windows]
@@ -38,7 +38,7 @@ gem 'rotp', '>= 5.0.0'
 gem 'rqrcode'
 
 # HTML pipeline and sanitization
-gem "html-pipeline", "~> 2.13.2"
+gem "html-pipeline", "~> 2.13.2", require: 'html/pipeline'
 gem "sanitize", "~> 6.0"
 
 # Optional gem for LDAP authentication

--- a/lib/redmine/acts/mentionable.rb
+++ b/lib/redmine/acts/mentionable.rb
@@ -31,7 +31,7 @@ module Redmine
 
           attr_accessor :mentioned_users
 
-          send :include, Redmine::Acts::Mentionable::InstanceMethods
+          include Redmine::Acts::Mentionable::InstanceMethods
 
           after_save :parse_mentions
         end

--- a/lib/redmine/acts/positioned.rb
+++ b/lib/redmine/acts/positioned.rb
@@ -36,7 +36,7 @@ module Redmine
           class_attribute :positioned_options
           self.positioned_options = {:scope => Array(options[:scope])}
 
-          send :include, Redmine::Acts::Positioned::InstanceMethods
+          include Redmine::Acts::Positioned::InstanceMethods
 
           before_save :set_default_position
           after_save :update_position


### PR DESCRIPTION
There is a name/path discrepancy issue. 

When you remove `require: false`, Bundler tries to auto-require the gem at boot using the gem name. But there's a mismatch:

| Gem Name | Bundler Auto-Requires | Actual Require Path |
|----------|----------------------|-------------------|
| `html-pipeline` | `require 'html_pipeline'` | `require 'html/pipeline'`  |
| `net-imap` | `require 'net_imap'` | `require 'net/imap'`  |
| `net-pop` | `require 'net_pop'` | `require 'net/pop'` |
| `net-smtp` | `require 'net_smtp'` | `require 'net/smtp'`  |

Without `require: false`, Bundler tries the wrong require path and fails with `LoadError`.

Bundler **cannot** auto-load them without crashing. They must be explicitly required in code only when needed:

```ruby
# In lib/redmine/wiki_formatting/common_mark/formatter.rb
require 'html/pipeline'

# In lib/redmine/imap.rb
# (implicit via Net::IMAP usage)
```

These exceptions are "masked" and not fatal yet this adds error tags to the telemetry traces for no good reason since this can be avoided and cleanly handled